### PR TITLE
Update mime type initializer for hydra-head update

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,10 +3,9 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 Mime::Type.register "application/n-triples", :nt
-Mime::Type.register "application/json", :jsonld
+Mime::Type.register "application/ld+json", :jsonld
 Mime::Type.register "text/turtle", :ttl
 
 Mime::Type.register "application/n-triples", :nt
-Mime::Type.register "application/json", :jsonld
 Mime::Type.register "text/turtle", :ttl
 Mime::Type.register 'application/x-endnote-refer', :endnote


### PR DESCRIPTION
- An update to hydra-head 9.2.2 requires a change to the mime types initializer
- removed duplicate mime type registrations.

Note: You should run `bundle update sufia` to get the latest dependencies

Refer to this release for the bug fix: https://github.com/projecthydra/hydra-head/releases/tag/v9.2.2
