### PR TITLE
update solr docker image references

### DIFF
--- a/bin/init-docker.sh
+++ b/bin/init-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 sudo docker run -d -p 8080:8080 --name fedora4 andrewkrug/fedora4
-sudo docker run -d -p 8081:8080 --name solr andrewkrug/solr
+sudo docker run -d -p 8081:8080 --name solr joelferrier/solr
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
   pre:
     - docker info
     - docker pull andrewkrug/fedora4
-    - docker pull andrewkrug/solr
+    - docker pull joelferrier/solr
 
 test:
   pre:


### PR DESCRIPTION
This incorporates a new docker image that is compatible with CircleCI.
When first running init-docker.sh the new docker image will be downloaded.
