### PR TITLE
Add seed data for production credits

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,3 +6,4 @@ User.find_or_create_by!(email: "trever@codingzeal.com") { |user| user.password =
 User.find_or_create_by!(email: "jeff.parr@codingzeal.com") { |user| user.password = "osfarchive2015"; user.display_name = "Jeff Parr"; user.group_list = "admin"}
 User.find_or_create_by!(email: "sean.culver@codingzeal.com") { |user| user.password = "osfarchive2015"; user.display_name = "Sean Culver"; user.group_list = "admin" }
 
+ProductionCredits::Engine.load_seed

--- a/vendor/engines/production_credits/db/seeds.rb
+++ b/vendor/engines/production_credits/db/seeds.rb
@@ -1,0 +1,15 @@
+module ProductionCredits
+  elizabethan = Venue.find_or_create_by!(name: "Elizabethan")
+  bowmer = Venue.find_or_create_by!(name: "Angus Bowmer")
+  Venue.find_or_create_by!(name: "Thomas")
+  Venue.find_or_create_by!(name: "The Green Show")
+  Venue.find_or_create_by!(name: "Craterian")
+  swan = Venue.find_or_create_by!(name: "The Black Swan")
+
+  hamlet = Work.find_or_create_by!(title: "Hamlet") { |work| work.author = "Shakespeare, William" }
+  wrinkle = Work.find_or_create_by!(title: "A Wrinkle in Time") { |work| work.author = "Madeleine l'Engle" }
+
+  Production.find_or_create_by!(production_name: "Hamlet 2005") { |p| p.open_on = "2005-04-01"; p.close_on = "2005-10-30"; p.work = hamlet; p.venue = elizabethan }
+  Production.find_or_create_by!(production_name: "Hamlet 1968") { |p| p.open_on = "1968-05-07"; p.close_on = "1968-11-01"; p.work = hamlet; p.venue = swan }
+  Production.find_or_create_by!(production_name: "A Wrinkle in Time") { |p| p.open_on = "2014-03-14"; p.close_on = "2014-09-15"; p.work = wrinkle; p.venue = bowmer }
+end


### PR DESCRIPTION
Add sample venues, works, and productions for use in testing search.

We would like more realistic data eventually, but this is enough to get us started.  We have the four primary venues as well as a couple of "other" venues.  We added two works, and three productions, two of which are for the same work.

We are not yet populating all of the fields because we don't need them; we'd like to get more realistic seed data from the client that is fully populated.
