### PR TITLE
Features/filter by year

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -68,6 +68,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("venue_name", :facetable), label: "Venue", limit: 5
     config.add_facet_field solr_name("work_name", :facetable), label: "Work", limit: 5
     config.add_facet_field solr_name("highlighted", :facetable), label: "Highlighted", limit: 5
+    config.add_facet_field solr_name("year_created", :facetable, type: :integer), label: "Year Created", limit: 5
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -326,6 +327,8 @@ class CatalogController < ApplicationController
     config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
     config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
     config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+    config.add_sort_field "#{solr_name('year_created', :stored_sortable)} asc", label: "year created \u25B2"
+    config.add_sort_field "#{solr_name('year_created', :stored_sortable)} desc", label: "year created \u25BC"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/models/file_search.rb
+++ b/app/models/file_search.rb
@@ -81,6 +81,6 @@ class FileSearch
 
   def year_filter
     return {} if year_range == year_range_limit
-    { Solrizer.solr_name("year_created") => [year_range] }
+    { Solrizer.solr_name("year_created", :stored_sortable, type: :integer) => [year_range] }
   end
 end

--- a/app/models/file_search.rb
+++ b/app/models/file_search.rb
@@ -19,6 +19,23 @@ class FileSearch
     params.fetch(:venues) { [] }
   end
 
+  def self.year_range_limit
+    1935..Date.today.year
+  end
+
+  def year_range_limit
+    self.class.year_range_limit
+  end
+
+  def year_range
+    raw = params.fetch(:years) { "" }
+    from, to = raw.split(";").map(&method(:Integer))
+    return year_range_limit unless from && to
+    from..to
+  rescue ArgumentError
+    year_range_limit
+  end
+
   def results
     SearchResults.new(files)
   end
@@ -48,6 +65,7 @@ class FileSearch
     {}
       .merge(work_filter)
       .merge(venue_filter)
+      .merge(year_filter)
   end
 
   def work_filter
@@ -59,5 +77,10 @@ class FileSearch
     # TODO: Handle venue "Other"
     return {} if venue_names.empty?
     { Solrizer.solr_name("venue_name") => venue_names }
+  end
+
+  def year_filter
+    return {} if year_range == year_range_limit
+    { Solrizer.solr_name("year_created") => [year_range] }
   end
 end

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -23,6 +23,11 @@ class GenericFile < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  property :year_created, predicate: ::RDF::URI('http://docs/osfashland.org/terms/year_created'), multiple: false do |index|
+    index.type :integer
+    index.as :stored_sortable, :facetable
+  end
+
   before_save :set_calculated_fields
 
   private
@@ -31,7 +36,7 @@ class GenericFile < ActiveFedora::Base
     self.production_name = production.production_name if production
     self.venue_name = venue.name if venue
     self.work_name = work.title if work
-    # self.asset_create_year = year_created if year_created
+    self.year_created = creation_year if creation_year
   end
 
   def work
@@ -48,5 +53,12 @@ class GenericFile < ActiveFedora::Base
     elsif production
       venue = production.venue
     end
+  end
+
+  def creation_year
+    first_date = date_created.try(:first)
+    first_date && Date.parse(first_date).year
+  rescue ArgumentError
+    nil
   end
 end

--- a/app/views/searches/_filters.html.erb
+++ b/app/views/searches/_filters.html.erb
@@ -23,7 +23,6 @@
                       venue.name,
                       {
                         "data-img-src" => "http://dummyimage.com/40x40/000/fff&text=#{venue.name}",
-                        "data-img-label" => venue.name,
                         class: "filter-venue-item" }]
                     }, @search.venue_names),
                   class: "js-venue-list filter-list",

--- a/app/views/searches/_filters.html.erb
+++ b/app/views/searches/_filters.html.erb
@@ -59,7 +59,13 @@
         <div class="search-filter filter-year">
           <div class="search-filter-inner">
             <h3 class="filter-title">Year Range</h3>
-            <input class="js-year-range" />
+            <input class="js-year-range"
+                   name="years"
+                   data-min="<%= @search.year_range_limit.begin %>"
+                   data-max="<%= @search.year_range_limit.end %>"
+                   data-from="<%= @search.year_range.begin %>"
+                   data-to="<%= @search.year_range.end %>"
+                   />
           </div>
         </div>
       </div>

--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -21,14 +21,11 @@
 
     $('.js-year-range').ionRangeSlider({
       type: "double",
-      min: "1935",
-      max: "2015",
       hide_min_max: true,
-      step: 1 //,
-      // onFinish: function () {
-      //   that.set('target', that.controller.get('target'));
-      //   that.send('search');
-      // }
+      step: 1,
+      onFinish: function () {
+        $('#filter-form').submit()
+      }
     });
 
     // Init the image gallery

--- a/spec/models/file_search_spec.rb
+++ b/spec/models/file_search_spec.rb
@@ -77,7 +77,7 @@ describe FileSearch do
     describe "by year range" do
       context "with a limited range" do
         let(:params) { { years: "1968;1991" } }
-        let(:expected_query) { { f: { year_created_isi: [1968..1991] } } }
+        let(:expected_query) { { f: { "year_created_isi" => [1968..1991] } } }
 
         it "returns found files" do
           expect(search.files).to eq files

--- a/spec/models/file_search_spec.rb
+++ b/spec/models/file_search_spec.rb
@@ -77,7 +77,7 @@ describe FileSearch do
     describe "by year range" do
       context "with a limited range" do
         let(:params) { { years: "1968;1991" } }
-        let(:expected_query) { { f: { Solrizer.solr_name("year_created") => [1968..1991] } } }
+        let(:expected_query) { { f: { year_created_isi: [1968..1991] } } }
 
         it "returns found files" do
           expect(search.files).to eq files

--- a/spec/models/file_search_spec.rb
+++ b/spec/models/file_search_spec.rb
@@ -73,5 +73,61 @@ describe FileSearch do
         end
       end
     end
+
+    describe "by year range" do
+      context "with a limited range" do
+        let(:params) { { years: "1968;1991" } }
+        let(:expected_query) { { f: { Solrizer.solr_name("year_created") => [1968..1991] } } }
+
+        it "returns found files" do
+          expect(search.files).to eq files
+        end
+      end
+
+      context "with the full date range" do
+        let(:params) { { years: "#{default_range.begin};#{default_range.end}" } }
+        let(:expected_query) { {} }
+        let(:default_range) { described_class.year_range_limit }
+
+        it "returns found files" do
+          expect(search.files).to eq files
+        end
+      end
+    end
+  end
+
+  describe "years parameter parsing" do
+    let(:range) { search.year_range }
+    let(:default_range) { described_class.year_range_limit }
+
+    context "with no years parameter" do
+      let(:params) { {} }
+
+      specify { expect(range).to eq default_range }
+    end
+
+    context "with empty years parameter" do
+      let(:params) { { years: "" } }
+
+      specify { expect(range).to eq default_range }
+    end
+
+    context "with no separator" do
+      let(:params) { { years: "1492" } }
+
+      specify { expect(range).to eq default_range }
+    end
+
+    context "with non-integer values" do
+      let(:params) { { years: "not;integer"} }
+
+      specify { expect(range).to eq default_range }
+    end
+
+    context "with valid range" do
+      let(:params) { { years: "1942;1968"} }
+
+      specify { expect(range).to eq 1942..1968 }
+    end
   end
 end

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -105,4 +105,38 @@ describe GenericFile do
       end
     end
   end
+
+  describe "creation year" do
+    context "when there is a creation date" do
+      let(:date) { "1968-03-07" }
+      before do
+        file.date_created = [date]
+        file.save!
+      end
+
+      it "sets the creation year" do
+        expect(file.year_created).to eq 1968
+      end
+    end
+
+    context "when there isn't a creation date" do
+      before do
+        file.date_created = nil
+      end
+
+      it "doesn't change the creation year" do
+        expect { file.save! }.not_to change { file.year_created }
+      end
+    end
+
+    context "when creation dates are empty" do
+      before do
+        file.date_created = []
+      end
+
+      it "doesn't change the creation year" do
+        expect { file.save! }.not_to change { file.year_created }
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Specify the min/max years in `FileSearch` rather than when setting up the range slider.
- Use `data-` attributes on the range slider to allow the controller to specify them.
- Default to the full year range if the parameter is not specified or invalid, but don’t include a year range filter at all if it is the full year range.
- Automatically submit the form when the slider is moved.
- Add solr field specs, largely copying from the old project.  The
  :stored_sortable/:stored_searchable/:facetable stuff is still
  confusing to me, and probably there is a way to clean this up.
- Add a new property to generic_file and compute its value in the
  before_save callback.
