### PR TITLE
Add editable About and Policies pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /vendor/engines/production_credits/spec/dummy/tmp/
 /vendor/engines/production_credits/spec/dummy/.sass-cache
 Gemfile.lock
+gems/

--- a/app/controllers/cms_pages_controller.rb
+++ b/app/controllers/cms_pages_controller.rb
@@ -1,0 +1,3 @@
+class CmsPagesController < PagesController
+  layout "client"
+end

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,0 +1,17 @@
+<div id="masthead_controls" class="container-fluid">
+  <div class="row">
+    <div class="col-xs-12 col-sm-5 col-md-6">
+      <nav class="navbar navbar-default" role="navigation">
+        <ul class="nav navbar-nav">
+            <li <%= 'class=active' if current_page?(root_path) %>><a href="/" >Home</a></li>
+                <li <%= 'class=active' if current_page?(sufia.about_path) %>><a href="/about/" >About</a></li>
+                <li <%= 'class=active' if action_name == "help" %>><a href="/help/" >Help</a></li>
+            <li <%= 'class=active' if current_page?(sufia.contact_path) %>><a href="<%= sufia.contact_form_index_path %>" >Contact</a></li>
+        </ul><!-- /.nav -->
+      </nav><!-- /.navbar -->
+    </div>
+    <div class="col-xs-12 col-sm-7 col-md-6">
+      <%= render partial: 'catalog/search_form' %>
+    </div>
+  </div> <!-- /.row -->
+</div><!-- /#masthead_controls -->

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -5,6 +5,7 @@
         <ul class="nav navbar-nav">
             <li <%= 'class=active' if current_page?(root_path) %>><a href="/" >Home</a></li>
                 <li <%= 'class=active' if current_page?(sufia.about_path) %>><a href="/about/" >About</a></li>
+                <li <%= 'class=active' if current_page?(admin_policies_path) %>><a href="<%= admin_policies_path %>">Policies</a></li>
                 <li <%= 'class=active' if action_name == "help" %>><a href="/help/" >Help</a></li>
             <li <%= 'class=active' if current_page?(sufia.contact_path) %>><a href="<%= sufia.contact_form_index_path %>" >Contact</a></li>
         </ul><!-- /.nav -->

--- a/app/views/cms_pages/show.html.erb
+++ b/app/views/cms_pages/show.html.erb
@@ -1,1 +1,2 @@
+<%= link_to "Back to Searches", searches_path %>
 <%= raw(@page.value) %>

--- a/app/views/cms_pages/show.html.erb
+++ b/app/views/cms_pages/show.html.erb
@@ -1,0 +1,1 @@
+<%= raw(@page.value) %>

--- a/app/views/searches/_footer.html.erb
+++ b/app/views/searches/_footer.html.erb
@@ -1,0 +1,4 @@
+<ul>
+  <li><%= link_to "About", public_about_path %></li>
+  <li><%= link_to "Terms of Use", policies_path %></li>
+</ul>

--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -6,8 +6,7 @@
     <%= render "filters" %>
   <% end %>
   <%= render "search_results" %>
-
-  <footer />
+  <%= render "footer" %>
 </div>
 
 <script type="text/javascript">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
   resources :searches
 
   get "public_about" => 'cms_pages#show', id: 'about_page'
+  get "policies" => 'cms_pages#show', id: 'policies_page'
+
+  # For editing via the Sufia backend
+  get "admin/policies" => 'pages#show', id: 'policies_page'
 
   root to: 'homepage#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,7 @@ Rails.application.routes.draw do
 
   resources :searches
 
+  get "public_about" => 'cms_pages#show', id: 'about_page'
+
   root to: 'homepage#index'
 end


### PR DESCRIPTION
Adds CMS-managed public About and Policies pages.

The About page is shared with the Sufia back-end and is editable via the standard About link on the Sufia pages.

The Policies page is different from Sufia’s Terms page because the latter is static, not editable.  We added in a link in the Sufia header to get to this policy page for editing.

The new pages are linked from a footer on the search page.

Everything is currently unstyled; that still needs to be done.
