### PR TITLE
Run the Rails engine specs on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,10 @@ dependencies:
     - docker info
     - docker pull andrewkrug/fedora4
     - docker pull joelferrier/solr
+  post:
+    - bundle install:
+        pwd:
+          vendor/engines/production_credits
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
 
 database:
   post:
-    - bin/rake db:migrate RAILS_ENV=test:
+    - bundle exec rake db:migrate RAILS_ENV=test:
         pwd:
           vendor/engines/production_credits
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,12 @@ dependencies:
         pwd:
           vendor/engines/production_credits
 
+database:
+  post:
+    - bin/rake db:migrate RAILS_ENV=test:
+        pwd:
+          vendor/engines/production_credits
+
 test:
   pre:
     - ./bin/init-docker.sh

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,8 @@ dependencies:
 
 test:
   pre:
-    - ./bin/init-docker.sh; sleep 10
-    - ./bin/start-docker.sh; sleep 10
+    - ./bin/init-docker.sh
+    - ./bin/start-docker.sh
     - curl --retry 10 --retry-delay 5 -v http://localhost:8080
     - curl --retry 10 --retry-delay 5 -v http://localhost:8081
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -18,4 +18,5 @@ test:
     - curl --retry 10 --retry-delay 5 -v http://localhost:8081
   post:
     - bundle exec rspec spec:
-      pwd: vendor/engines/production_credits
+      pwd:
+        vendor/engines/production_credits

--- a/circle.yml
+++ b/circle.yml
@@ -16,3 +16,6 @@ test:
     - ./bin/start-docker.sh; sleep 10
     - curl --retry 10 --retry-delay 5 -v http://localhost:8080
     - curl --retry 10 --retry-delay 5 -v http://localhost:8081
+  post:
+    - bundle exec rspec spec:
+      pwd: vendor/engines/production_credits

--- a/circle.yml
+++ b/circle.yml
@@ -18,5 +18,5 @@ test:
     - curl --retry 10 --retry-delay 5 -v http://localhost:8081
   post:
     - bundle exec rspec spec:
-      pwd:
-        vendor/engines/production_credits
+        pwd:
+          vendor/engines/production_credits

--- a/vendor/engines/production_credits/Gemfile
+++ b/vendor/engines/production_credits/Gemfile
@@ -13,9 +13,4 @@ gemspec
 # To use debugger
 # gem 'debugger'
 
-
-group :development, :test do
-  gem "rspec-rails"
-  gem 'factory_girl_rails'
-  gem 'shoulda-matchers', require: false
-end
+gem 'rails_admin', github: 'codingzeal/rails_admin', branch: 'sufia-6.2.0'


### PR DESCRIPTION
- Add rails_admin to the Gemfile so that the specs can run.
- Add the necessary commands to circle.yml to bundle, migrate, and run the specs.
