### PR TITLE
Removing Rubycop line length requirement

### DIFF
--- a/.ruby_style.yml
+++ b/.ruby_style.yml
@@ -509,7 +509,7 @@ Metrics/CyclomaticComplexity:
 Metrics/LineLength:
   Description: Limit lines to 80 characters.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
-  Enabled: true
+  Enabled: false
   Max: 80
   Exclude:
   - app/controllers/catalog_controller.rb


### PR DESCRIPTION
I'd love to support this, currently the time investment and annoyance level is just too high.

Should review later to see if it is worthwhile to turn back on.
