### PR TITLE
Use canonical venue names in front-end

### DIFF
--- a/app/views/searches/_filters.html.erb
+++ b/app/views/searches/_filters.html.erb
@@ -18,11 +18,11 @@
           <div class="search-filter-inner">
             <h3 class="filter-title">Venue</h3>
             <%= select_tag "venues[]",
-                  options_for_select(@search.all_venues.map { |venue|
+                  options_for_select(@search.all_venue_names.map { |name|
                     [
-                      venue.name,
+                      name,
                       {
-                        "data-img-src" => image_path("icons/icon-#{venue.name.parameterize}"),
+                        "data-img-src" => image_path("icons/icon-#{name.parameterize}"),
                         class: "filter-venue-item" }]
                     }, @search.venue_names),
                   class: "js-venue-list",

--- a/spec/models/file_search_spec.rb
+++ b/spec/models/file_search_spec.rb
@@ -79,12 +79,6 @@ describe FileSearch do
     end
 
     describe "by venue" do
-      before do
-        described_class::PRIMARY_VENUES.each do |name|
-          ProductionCredits::Venue.create(name: name)
-        end
-      end
-
       context "with one venue selected" do
         let(:params) { { venues: %w[VENUE] } }
         let(:expected_query) { { f: { "venue_names_sim" => %w[VENUE], "resource_type_sim" => ["Audio"] } } }
@@ -105,7 +99,7 @@ describe FileSearch do
 
       context "with other venue selected" do
         let(:params) { { venues: [described_class::OTHER_VENUE] } }
-        let(:expected_query) { { f: { "!venue_names_sim" => described_class::PRIMARY_VENUES, "resource_type_sim" => ["Audio"] } } }
+        let(:expected_query) { { f: { "!venue_names_sim" => described_class::PRIMARY_VENUES.values, "resource_type_sim" => ["Audio"] } } }
 
         it "returns found files" do
           expect(search.result.files).to eq files
@@ -113,8 +107,8 @@ describe FileSearch do
       end
 
       context "with the other venue and some primary venues selected" do
-        let(:params) { { venues: described_class::PRIMARY_VENUES.take(2) + [described_class::OTHER_VENUE] } }
-        let(:expected_query) { { f: { "!venue_names_sim" => described_class::PRIMARY_VENUES.drop(2), "resource_type_sim" => ["Audio"] } } }
+        let(:params) { { venues: described_class::PRIMARY_VENUES.keys.take(2) + [described_class::OTHER_VENUE] } }
+        let(:expected_query) { { f: { "!venue_names_sim" => described_class::PRIMARY_VENUES.values.drop(2), "resource_type_sim" => ["Audio"] } } }
 
         it "returns found files" do
           expect(search.result.files).to eq files


### PR DESCRIPTION
FileSearch now maps those names to the names in the current version of
the production_credits seed data.
