### PR TITLE
Clean up date formatting on search results

### DIFF
--- a/app/views/searches/_images.html.erb
+++ b/app/views/searches/_images.html.erb
@@ -22,7 +22,7 @@
                   <%= image.title.first %>
                 </h1>
                 <p class="card__content__date">
-                  <%= image.date_created.first %>
+                  <%= image.date_created.first.to_date.to_s(:long) %>
                 </p>
               </div>
             </a>
@@ -47,7 +47,7 @@
                 <p><%= image.production_names.join(", ") %></p>
                 <p><%= image.venue_names.join(", ") %></p>
                 <p><%= image.description.first %></p>
-                <p><%= image.date_created.first %></p>
+                <p><%= image.date_created.first.to_date.to_s(:long) %></p>
               </figcaption>
             </figure>
           </li>

--- a/app/views/searches/_images.html.erb
+++ b/app/views/searches/_images.html.erb
@@ -22,7 +22,7 @@
                   <%= image.title.first %>
                 </h1>
                 <p class="card__content__date">
-                  <%= image.date_created.first.to_date.to_s(:long) %>
+                  <%= image.date_created.first.to_date.to_s(:mdy) %>
                 </p>
               </div>
             </a>
@@ -47,7 +47,7 @@
                 <p><%= image.production_names.join(", ") %></p>
                 <p><%= image.venue_names.join(", ") %></p>
                 <p><%= image.description.first %></p>
-                <p><%= image.date_created.first.to_date.to_s(:long) %></p>
+                <p><%= image.date_created.first.to_date.to_s(:mdy) %></p>
               </figcaption>
             </figure>
           </li>

--- a/app/views/searches/_videos.html.erb
+++ b/app/views/searches/_videos.html.erb
@@ -24,7 +24,7 @@
               <%= video.venue_names.join(", ") %>
             </h4>
             <p class="card__content__date">
-              <%= video.date_created.first.to_date.to_s(:long) %>
+              <%= video.date_created.first.to_date.to_s(:mdy) %>
             </p>
           </div>
         </a>

--- a/app/views/searches/_videos.html.erb
+++ b/app/views/searches/_videos.html.erb
@@ -24,7 +24,7 @@
               <%= video.venue_names.join(", ") %>
             </h4>
             <p class="card__content__date">
-              <%= video.date_created.first %>
+              <%= video.date_created.first.to_date.to_s(:long) %>
             </p>
           </div>
         </a>

--- a/app/views/searches/images.html.erb
+++ b/app/views/searches/images.html.erb
@@ -11,7 +11,7 @@
           <%= image.title.first %>
         </h1>
         <p class="card__content__date">
-          <%= image.date_created.first.to_date.to_s(:long) %>
+          <%= image.date_created.first.to_date.to_s(:mdy) %>
         </p>
       </div>
     </a>
@@ -29,7 +29,7 @@
         <p><%= image.production_names.join(',') %></p>
         <p><%= image.venue_names.join(',') %></p>
         <p><%= image.description.first %></p>
-        <p><%= image.date_created.first.to_date.to_s(:long) %></p>
+        <p><%= image.date_created.first.to_date.to_s(:mdy) %></p>
       </figcaption>
     </figure>
   </li>

--- a/app/views/searches/images.html.erb
+++ b/app/views/searches/images.html.erb
@@ -11,7 +11,7 @@
           <%= image.title.first %>
         </h1>
         <p class="card__content__date">
-          <%= image.date_created.first %>
+          <%= image.date_created.first.to_date.to_s(:long) %>
         </p>
       </div>
     </a>
@@ -29,7 +29,7 @@
         <p><%= image.production_names.join(',') %></p>
         <p><%= image.venue_names.join(',') %></p>
         <p><%= image.description.first %></p>
-        <p><%= image.date_created.first %></p>
+        <p><%= image.date_created.first.to_date.to_s(:long) %></p>
       </figcaption>
     </figure>
   </li>

--- a/app/views/searches/videos.html.erb
+++ b/app/views/searches/videos.html.erb
@@ -17,7 +17,7 @@
               <%= video.venue_names %>
             </h4>
             <p class="card__content__date">
-              <%= video.date_created.first %>
+              <%= video.date_created.first.to_date.to_s(:long) %>
             </p>
           </div>
         </a>

--- a/app/views/searches/videos.html.erb
+++ b/app/views/searches/videos.html.erb
@@ -17,7 +17,7 @@
               <%= video.venue_names %>
             </h4>
             <p class="card__content__date">
-              <%= video.date_created.first.to_date.to_s(:long) %>
+              <%= video.date_created.first.to_date.to_s(:mdy) %>
             </p>
           </div>
         </a>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,1 @@
-Date::DATE_FORMATS[:mdy] = '%m/%d/%Y'
+Date::DATE_FORMATS[:mdy] = "%m/%d/%Y"

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,1 @@
+Date::DATE_FORMATS[:mdy] = '%m/%d/%Y'


### PR DESCRIPTION
This is a lot of duplication.  We should eventually wrap the
GenericFiles coming back from search in a presenter or decorator, then
create a method on the presenter to do this formatting.

@tyarrish Are we ok with long-format here?  Or should we use a
different format?
