### PR TITLE
Rename highlighted to curated

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -72,7 +72,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("production_names", :facetable), label: "Productions", limit: 5
     config.add_facet_field solr_name("venue_names", :facetable), label: "Venues", limit: 5
     config.add_facet_field solr_name("work_name", :facetable), label: "Work", limit: 5
-    config.add_facet_field solr_name("highlighted", :facetable), label: "Highlighted", limit: 5
+    config.add_facet_field solr_name("curated", :facetable), label: "Curated", limit: 5
     config.add_facet_field(solr_name("year_created", :facetable, type: :integer), label: "Year Created", limit: 5)
 
     # Have BL send all facet field names to Solr, which has been the default
@@ -101,7 +101,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("production_names", :stored_searchable), label: "Productions"
     config.add_index_field solr_name("venue_names", :stored_searchable), label: "Venues"
     config.add_index_field solr_name("work_name", :stored_searchable), label: "Work"
-    config.add_index_field solr_name("highlighted", :stored_searchable), label: "Highlighted"
+    config.add_index_field solr_name("curated", :stored_searchable), label: "Curated"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -124,7 +124,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("production_names", :stored_searchable), label: "Productions"
     config.add_show_field solr_name("venue_names", :stored_searchable), label: "Venues"
     config.add_show_field solr_name("work_name", :stored_searchable), label: "Work"
-    config.add_show_field solr_name("highlighted", :stored_searchable), label: "Highlighted"
+    config.add_show_field solr_name("curated", :stored_searchable), label: "Curated"
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -72,7 +72,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("production_names", :facetable), label: "Productions", limit: 5
     config.add_facet_field solr_name("venue_names", :facetable), label: "Venues", limit: 5
     config.add_facet_field solr_name("work_names", :facetable), label: "Work", limit: 5
-    config.add_facet_field solr_name("highlighted", :facetable), label: "Highlighted", limit: 5
+    config.add_facet_field solr_name("curated", :facetable), label: "Curated", limit: 5
     config.add_facet_field(solr_name("year_created", :facetable, type: :integer), label: "Year Created", limit: 5)
 
     # Have BL send all facet field names to Solr, which has been the default
@@ -101,7 +101,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("production_names", :stored_searchable), label: "Productions"
     config.add_index_field solr_name("venue_names", :stored_searchable), label: "Venues"
     config.add_index_field solr_name("work_names", :stored_searchable), label: "Work"
-    config.add_index_field solr_name("highlighted", :stored_searchable), label: "Highlighted"
+    config.add_index_field solr_name("curated", :stored_searchable), label: "Curated"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -124,7 +124,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("production_names", :stored_searchable), label: "Productions"
     config.add_show_field solr_name("venue_names", :stored_searchable), label: "Venues"
     config.add_show_field solr_name("work_names", :stored_searchable), label: "Work"
-    config.add_show_field solr_name("highlighted", :stored_searchable), label: "Highlighted"
+    config.add_show_field solr_name("curated", :stored_searchable), label: "Curated"
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/models/file_search.rb
+++ b/app/models/file_search.rb
@@ -119,13 +119,13 @@ class FileSearch
       .merge(venue_filter)
       .merge(year_filter)
       .merge(resource_type_filter)
-      .merge(highlight_filter)
+      .merge(curated_filter)
   end
 
-  def highlight_filter
-    # 'highlighted' is only used on first view of index
+  def curated_filter
+    # 'curated' is only used on first view of index
     return {} if has_query_params?
-    { Solrizer.solr_name("highlighted", :facetable) => "1" }
+    { Solrizer.solr_name("curated", :facetable) => [1] }
   end
 
   def resource_type_filter

--- a/app/models/file_search.rb
+++ b/app/models/file_search.rb
@@ -115,13 +115,13 @@ class FileSearch
       .merge(venue_filter)
       .merge(year_filter)
       .merge(resource_type_filter)
-      .merge(highlight_filter)
+      .merge(curated_filter)
   end
 
-  def highlight_filter
-    # 'highlighted' is only used on first view of index
+  def curated_filter
+    # 'curated' is only used on first view of index
     return {} if has_query_params?
-    { Solrizer.solr_name("highlighted", :facetable) => "1" }
+    { Solrizer.solr_name("curated", :facetable) => [1] }
   end
 
   def resource_type_filter

--- a/app/models/file_search.rb
+++ b/app/models/file_search.rb
@@ -121,7 +121,7 @@ class FileSearch
   def curated_filter
     # 'curated' is only used on first view of index
     return {} if has_query_params?
-    { Solrizer.solr_name("curated", :facetable) => [1] }
+    { Solrizer.solr_name("curated", :facetable) => "1" }
   end
 
   def resource_type_filter

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -24,7 +24,7 @@ class GenericFile < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
-  property :highlighted, multiple: false do |index|
+  property :curated, multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
 

--- a/app/presenters/generic_file_presenter.rb
+++ b/app/presenters/generic_file_presenter.rb
@@ -16,7 +16,7 @@ class GenericFilePresenter < Sufia::GenericFilePresenter
     :production_ids,
     :venue_ids,
     :work_ids,
-    :highlighted
+    :curated
   ]
 
   # Names are not displayed directly so don't include them in `terms'.

--- a/app/presenters/generic_file_presenter.rb
+++ b/app/presenters/generic_file_presenter.rb
@@ -16,7 +16,7 @@ class GenericFilePresenter < Sufia::GenericFilePresenter
     :production_ids,
     :venue_ids,
     :work_id,
-    :highlighted
+    :curated
   ]
 
   # Names are not displayed directly so don't include them in `terms'.

--- a/app/views/records/edit_fields/_curated.html.erb
+++ b/app/views/records/edit_fields/_curated.html.erb
@@ -1,0 +1,1 @@
+<%= f.input :curated, as: :boolean, inline_label: true, label: "Curated" %>

--- a/app/views/records/edit_fields/_highlighted.html.erb
+++ b/app/views/records/edit_fields/_highlighted.html.erb
@@ -1,1 +1,0 @@
-<%= f.input :highlighted, as: :boolean, inline_label: true, label: "Highlighted" %>

--- a/spec/models/file_search_spec.rb
+++ b/spec/models/file_search_spec.rb
@@ -28,7 +28,7 @@ describe FileSearch do
   context "with no params" do
     let(:params) { { } }
     let(:resource_type) { :audio }
-    let(:expected_query) { { "f": { "resource_type_sim" => ["Audio"], "highlighted_sim" => "1" } } }
+    let(:expected_query) { { "f": { "resource_type_sim" => ["Audio"], "curated_sim" => "1" } } }
     let(:document_ids) { [42, 58] }
     let(:documents) { document_ids.map { |id| double("SolrDocument", id: id) } }
 
@@ -37,7 +37,7 @@ describe FileSearch do
       allow(file_query).to receive(:find).with(document_ids) { files }
     end
 
-    it "returns highlighted files" do
+    it "returns curated files" do
       expect(search.result.files).to eq files
     end
 

--- a/spec/models/file_search_spec.rb
+++ b/spec/models/file_search_spec.rb
@@ -26,7 +26,7 @@ describe FileSearch do
   context "with no params" do
     let(:params) { { } }
     let(:resource_type) { :audio }
-    let(:expected_query) { { "f": { "resource_type_sim" => ["Audio"], "highlighted_sim" => "1" } } }
+    let(:expected_query) { { "f": { "resource_type_sim" => ["Audio"], "curated_sim" => "1" } } }
     let(:document_ids) { [42, 58] }
     let(:documents) { document_ids.map { |id| double("SolrDocument", id: id) } }
 
@@ -35,7 +35,7 @@ describe FileSearch do
       allow(file_query).to receive(:find).with(document_ids) { files }
     end
 
-    it "returns highlighted files" do
+    it "returns curated files" do
       expect(search.result.files).to eq files
     end
 


### PR DESCRIPTION
The curated flag determines which resources appear on initial view of the search page (prior to any search or filter being applied).
