### PR TITLE
Chores/date cleanups

### DIFF
--- a/app/controllers/generic_files_controller.rb
+++ b/app/controllers/generic_files_controller.rb
@@ -10,7 +10,7 @@ class GenericFilesController < ApplicationController
       @generic_file.set_discover_groups(%w[public], [])
       params[:visibility] = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
     end
-    
+
     super
   end
 end

--- a/app/forms/file_edit_form.rb
+++ b/app/forms/file_edit_form.rb
@@ -2,5 +2,5 @@ class FileEditForm < GenericFilePresenter
   include HydraEditor::Form
   include HydraEditor::Form::Permissions
 
-  self.required_fields = [:title, :rights]
+  self.required_fields = %i[title rights date_created]
 end

--- a/app/views/records/edit_fields/_date_created.html.erb
+++ b/app/views/records/edit_fields/_date_created.html.erb
@@ -1,4 +1,9 @@
 <div class="form-group optional generic_file_identifier">
   <%= f.label :date_created %>
-  <%= f.date_field :date_created, class: 'form-control', name: "generic_file[date_created][]", value: "#{@generic_file.date_created.first if @generic_file}" %>
+  <%= f.date_field :date_created,
+                   class: 'form-control',
+                   name: "generic_file[date_created][]",
+                   value: "#{@generic_file.date_created.first if @generic_file}",
+                   required: f.object.required?(:date_created)
+  %>
 </div>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,1 @@
-Date::DATE_FORMATS[:mdy] = "%m/%d/%Y"
+Date::DATE_FORMATS[:mdy] = "%-m/%-d/%Y"


### PR DESCRIPTION
In order to make `date_created` a required field, I needed to add the `required` attribute to the form helper as well as adding to `required_fields` in `FileEditForm`.

The form helper is using the Rails `date_field` helper rather than the
SimpleForm version.  That means that the `aria-required` attribute is
not being set as it is for other form fields.  I tried to switch to the
SimpleForm variant, but it blew up because `date_created` is actually a
String, not a Date.  I gave up on this for now.
