### PR TITLE
Don't auto-populate venues

### DIFF
--- a/app/models/updates_production_credits.rb
+++ b/app/models/updates_production_credits.rb
@@ -22,7 +22,6 @@ class UpdatesProductionCredits
   end
 
   def update_venues
-    generic_file.venue_ids = venues.map(&:id).compact.map(&:to_s)
     generic_file.venue_names = venues.map(&:name).compact
   end
 
@@ -40,8 +39,8 @@ class UpdatesProductionCredits
 
   def venues
     @venues ||= begin
-      ids = generic_file.venue_ids || []
-      (ids.any? ? ProductionCredits::Venue.find(ids) : productions.map(&:venue)).compact
+      ids = generic_file.venue_ids
+      ids ? ProductionCredits::Venue.find(ids).compact : []
     end
   end
 

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -28,6 +28,7 @@ describe GenericFilesController do
       .with([production.id.to_s]) { [production] }
     allow(ProductionCredits::Production).to receive(:find).with([]) { [] }
     allow(ProductionCredits::Venue).to receive(:find).with([venue.id.to_s]) { [venue] }
+    allow(ProductionCredits::Venue).to receive(:find).with([]) { [] }
     sign_in user
     post :update, id: generic_file, generic_file: attributes
   end

--- a/spec/models/updates_production_credits_spec.rb
+++ b/spec/models/updates_production_credits_spec.rb
@@ -7,12 +7,10 @@ describe UpdatesProductionCredits do
     instance_double(ProductionCredits::Production,
                     id: 42,
                     production_name: "PRODUCTION",
-                    venue: production_venue,
                     work: production_work
     )
   end
   let(:venue) { instance_double(ProductionCredits::Venue, id: 58, name: "VENUE") }
-  let(:production_venue) { instance_double(ProductionCredits::Venue, id: 42, name: "PRODUCTION VENUE") }
   let(:work) { instance_double(ProductionCredits::Work, id: 123, title: "WORK") }
   let(:production_work) { instance_double(ProductionCredits::Work, id: 443, title: "PRODUCTION WORK") }
 
@@ -136,32 +134,11 @@ describe UpdatesProductionCredits do
       before do
         file.venue_ids = []
         file.venue_names = ["VENUE"]
+        subject.update
       end
 
-      context "when there are productions" do
-        before do
-          file.production_ids = [production.id]
-          subject.update
-        end
-
-        it "uses the productions' venue's ids" do
-          expect(file.venue_ids).to eq [production_venue.id.to_s]
-        end
-
-        it "uses the productions' venue's names" do
-          expect(file.venue_names).to eq [production_venue.name]
-        end
-      end
-
-      context "when there aren't productions" do
-        before do
-          file.production_ids = []
-          subject.update
-        end
-
-        it "clears the venue name" do
-          expect(file.venue_names).to be_empty
-        end
+      it "clears the venue name" do
+        expect(file.venue_names).to be_empty
       end
     end
 


### PR DESCRIPTION
It’s perfectly reasonable to have an item associated with productions, but not specific venues.
