### PR TITLE
Features/multiple venues

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150717205436) do
+ActiveRecord::Schema.define(version: 20150923180044) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -180,12 +180,18 @@ ActiveRecord::Schema.define(version: 20150717205436) do
     t.date    "open_on"
     t.date    "close_on"
     t.integer "work_id"
-    t.integer "venue_id"
     t.string  "venue_alias"
   end
 
-  add_index "production_credits_productions", ["venue_id"], name: "index_production_credits_productions_on_venue_id"
   add_index "production_credits_productions", ["work_id"], name: "index_production_credits_productions_on_work_id"
+
+  create_table "production_credits_productions_venues", id: false, force: :cascade do |t|
+    t.integer "production_id"
+    t.integer "venue_id"
+  end
+
+  add_index "production_credits_productions_venues", ["production_id", "venue_id"], name: "index_productions_venues"
+  add_index "production_credits_productions_venues", ["venue_id", "production_id"], name: "index_venues_productions"
 
   create_table "production_credits_venues", force: :cascade do |t|
     t.string   "name"

--- a/vendor/engines/production_credits/app/models/production_credits/production.rb
+++ b/vendor/engines/production_credits/app/models/production_credits/production.rb
@@ -1,7 +1,7 @@
 module ProductionCredits
   class Production < ActiveRecord::Base
     belongs_to :work
-    belongs_to :venue
+    has_and_belongs_to_many :venues
 
     validates_presence_of :production_name
     validates_presence_of :open_on

--- a/vendor/engines/production_credits/app/models/production_credits/venue.rb
+++ b/vendor/engines/production_credits/app/models/production_credits/venue.rb
@@ -1,6 +1,6 @@
 module ProductionCredits
   class Venue < ActiveRecord::Base
-    has_many :productions
+    has_and_belongs_to_many :productions
     validates_presence_of :name
 
 
@@ -9,7 +9,7 @@ module ProductionCredits
       if venue_name.empty?
         venue_name = name
       else
-        venue_name = venue_name.last.first 
+        venue_name = venue_name.last.first
       end
       ProductionCredits::Venue.where(name: venue_name).first
     end

--- a/vendor/engines/production_credits/db/migrate/20150923180044_create_join_table_productions_venues.rb
+++ b/vendor/engines/production_credits/db/migrate/20150923180044_create_join_table_productions_venues.rb
@@ -1,0 +1,12 @@
+class CreateJoinTableProductionsVenues < ActiveRecord::Migration
+  def change
+    create_table :production_credits_productions_venues, id: false do |t|
+      t.references :production
+      t.references :venue
+      t.index [:production_id, :venue_id], name: :index_productions_venues
+      t.index [:venue_id, :production_id], name: :index_venues_productions
+    end
+
+    remove_reference :production_credits_productions, :venue, index: true
+  end
+end

--- a/vendor/engines/production_credits/spec/dummy/config/environments/production.rb
+++ b/vendor/engines/production_credits/spec/dummy/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/vendor/engines/production_credits/spec/dummy/config/environments/test.rb
+++ b/vendor/engines/production_credits/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/vendor/engines/production_credits/spec/dummy/db/schema.rb
+++ b/vendor/engines/production_credits/spec/dummy/db/schema.rb
@@ -11,101 +11,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150126193826) do
+ActiveRecord::Schema.define(version: 20150923180044) do
 
-  create_table "credits", force: true do |t|
-    t.string  "credit_type"
-    t.integer "work_id"
-    t.integer "production_id"
-    t.integer "performance_id"
-    t.integer "role_id"
-    t.integer "person_id"
-  end
-
-  add_index "credits", ["performance_id"], name: "index_credits_on_performance_id"
-  add_index "credits", ["person_id"], name: "index_credits_on_person_id"
-  add_index "credits", ["production_id"], name: "index_credits_on_production_id"
-  add_index "credits", ["role_id"], name: "index_credits_on_role_id"
-  add_index "credits", ["work_id"], name: "index_credits_on_work_id"
-
-  create_table "names", force: true do |t|
-    t.string   "full_name"
-    t.integer  "person_id"
-    t.integer  "venue_id"
-    t.datetime "cannonized_at"
-  end
-
-  add_index "names", ["person_id"], name: "index_names_on_person_id"
-  add_index "names", ["venue_id"], name: "index_names_on_venue_id"
-
-  create_table "people", force: true do |t|
-    t.string "denormalized_full_name"
-    t.string "disambiguation"
-    t.date   "date_of_birth"
-  end
-
-  create_table "performances", force: true do |t|
-    t.integer  "production_id"
-    t.datetime "performed_at"
-  end
-
-  add_index "performances", ["production_id"], name: "index_performances_on_production_id"
-
-  create_table "production_credits_productions", force: true do |t|
+  create_table "production_credits_productions", force: :cascade do |t|
     t.string  "production_name"
     t.string  "category"
     t.date    "open_on"
     t.date    "close_on"
     t.integer "work_id"
-    t.integer "venue_id"
     t.string  "venue_alias"
   end
 
-  add_index "production_credits_productions", ["venue_id"], name: "index_production_credits_productions_on_venue_id"
   add_index "production_credits_productions", ["work_id"], name: "index_production_credits_productions_on_work_id"
 
-  create_table "production_credits_venues", force: true do |t|
+  create_table "production_credits_productions_venues", id: false, force: :cascade do |t|
+    t.integer "production_id"
+    t.integer "venue_id"
+  end
+
+  add_index "production_credits_productions_venues", ["production_id", "venue_id"], name: "index_productions_venues"
+  add_index "production_credits_productions_venues", ["venue_id", "production_id"], name: "index_venues_productions"
+
+  create_table "production_credits_venues", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "production_credits_works", force: true do |t|
+  create_table "production_credits_works", force: :cascade do |t|
     t.string   "title"
     t.string   "author"
     t.date     "year_written"
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-  end
-
-  create_table "productions", force: true do |t|
-    t.integer "work_id"
-    t.date    "open_on"
-    t.date    "close_on"
-  end
-
-  add_index "productions", ["work_id"], name: "index_productions_on_work_id"
-
-  create_table "roles", force: true do |t|
-    t.string  "category"
-    t.string  "name"
-    t.integer "work_id"
-    t.integer "production_id"
-  end
-
-  add_index "roles", ["production_id"], name: "index_roles_on_production_id"
-  add_index "roles", ["work_id"], name: "index_roles_on_work_id"
-
-  create_table "venues", force: true do |t|
-    t.string "denormalized_name"
-    t.date   "opened_on"
-  end
-
-  create_table "works", force: true do |t|
-    t.string  "title"
-    t.string  "medium"
-    t.integer "year"
   end
 
 end

--- a/vendor/engines/production_credits/spec/models/production_credits/production_spec.rb
+++ b/vendor/engines/production_credits/spec/models/production_credits/production_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module ProductionCredits
   describe Production, :type => :model do
-    it {should belong_to :work}
-    it {should belong_to :venue}
+    it { should belong_to :work }
+    it { should have_and_belong_to_many :venues }
   end
 end

--- a/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
+++ b/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 module ProductionCredits
   RSpec.describe Venue, :type => :model do
-    it {should have_many :productions}
+    it { should have_and_belong_to_many :productions }
   end
 end


### PR DESCRIPTION
- We had to create the join table manually rather than using
  `create_join_table` as `create_join_table` doesn’t seem to handle the
  isolated namespace in the engine properly.  It doesn’t name the ID
  columns correctly.
- Eliminate a deprecation warning: `serve_static_assets` has been renamed to `serve_static_files`
