### PR TITLE
Allow items to have an event type

### DIFF
--- a/app/controllers/batch_edits_controller.rb
+++ b/app/controllers/batch_edits_controller.rb
@@ -3,14 +3,6 @@ class BatchEditsController < ApplicationController
   include GenericFileHelper
   include Sufia::BatchEditsControllerBehavior
 
-  def self.edit_form_class
-    BatchEditForm
-  end
-
-  def terms
-    self.class.edit_form_class.terms
-  end
-
   # This is an override of sufia/app/controllers/concerns/sufia/batch_edits_controller_behavior.rb.
   # See below for changes.
   def edit
@@ -46,8 +38,25 @@ class BatchEditsController < ApplicationController
     @generic_file.permissions_attributes = [{ type: "group", name: "public", access: "read" }]
   end
 
+  private
+
+  # Override to keep singular properties singular
+  def initialize_fields(attributes, file)
+    terms.each do |key|
+      file[key] = attributes[key]
+    end
+  end
+
+  def terms
+    self.class.edit_form_class.terms
+  end
+
   def generic_file_params
     file_params = params[:generic_file] || ActionController::Parameters.new
     self.class.edit_form_class.model_attributes(file_params)
+  end
+
+  def self.edit_form_class
+    BatchEditForm
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -72,6 +72,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("production_names", :facetable), label: "Productions", limit: 5
     config.add_facet_field solr_name("venue_names", :facetable), label: "Venues", limit: 5
     config.add_facet_field solr_name("work_names", :facetable), label: "Work", limit: 5
+    config.add_facet_field solr_name("event_type_name", :facetable), label: "Event Types", limit: 5
     config.add_facet_field solr_name("curated", :facetable), label: "Curated", limit: 5
     config.add_facet_field(solr_name("year_created", :facetable, type: :integer), label: "Year Created", limit: 5)
 
@@ -101,6 +102,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("production_names", :stored_searchable), label: "Productions"
     config.add_index_field solr_name("venue_names", :stored_searchable), label: "Venues"
     config.add_index_field solr_name("work_names", :stored_searchable), label: "Work"
+    config.add_index_field solr_name("event_type_name", :stored_searchable), label: "Event Types"
     config.add_index_field solr_name("curated", :stored_searchable), label: "Curated"
 
     # solr fields to be displayed in the show (single result) view
@@ -124,6 +126,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("production_names", :stored_searchable), label: "Productions"
     config.add_show_field solr_name("venue_names", :stored_searchable), label: "Venues"
     config.add_show_field solr_name("work_names", :stored_searchable), label: "Work"
+    config.add_show_field solr_name("event_type_name", :stored_searchable), label: "Event Types"
     config.add_show_field solr_name("curated", :stored_searchable), label: "Curated"
 
     # "fielded" search configuration. Used by pulldown among other places.

--- a/app/helpers/generic_file_production_helper.rb
+++ b/app/helpers/generic_file_production_helper.rb
@@ -1,22 +1,22 @@
 module GenericFileProductionHelper
   def productions_for_select
     productions = ProductionCredits::Production.order(:production_name)
-    productions.collect{|p| {"#{p.production_name} - #{p.open_on.year}" => p.id}}.reduce({}, :update)
+    productions.map {|p| {"#{p.production_name} - #{p.open_on.year}" => p.id } }.reduce({}, :update)
   end
 
   def works_for_select
     works = ProductionCredits::Work.order(:title)
-    works.collect{|w| {"#{w.title}" => w.id}}.reduce({}, :update)
+    works.map {|w| { w.title => w.id } }.reduce({}, :update)
   end
 
   def venues_for_select
     venues = ProductionCredits::Venue.order(:name)
-    venues.collect{|v| {"#{v.name}" => v.id}}.reduce({}, :update)
+    venues.map {|v| { v.name => v.id } }.reduce({}, :update)
   end
 
   def event_types_for_select
     types = ProductionCredits::EventType.order(:name)
-    types.collect { |type| { type.name => type.id } }.reduce({}, :update)
+    types.map { |type| { type.name => type.id } }.reduce({}, :update)
   end
 
   def formatted_creation_date(file)

--- a/app/helpers/generic_file_production_helper.rb
+++ b/app/helpers/generic_file_production_helper.rb
@@ -14,10 +14,15 @@ module GenericFileProductionHelper
     venues.collect{|v| {"#{v.name}" => v.id}}.reduce({}, :update)
   end
 
+  def event_types_for_select
+    types = ProductionCredits::EventType.order(:name)
+    types.collect { |type| { type.name => type.id } }.reduce({}, :update)
+  end
+
   def formatted_creation_date(file)
     date = file.date_created.first
     return "" unless date
-    
+
     date.to_date.to_s(:mdy)
   end
 end

--- a/app/helpers/generic_file_production_helper.rb
+++ b/app/helpers/generic_file_production_helper.rb
@@ -1,17 +1,17 @@
 module GenericFileProductionHelper
   def productions_for_select
     productions = ProductionCredits::Production.order(:production_name)
-    productions.map {|p| {"#{p.production_name} - #{p.open_on.year}" => p.id } }.reduce({}, :update)
+    productions.map { |p| { "#{p.production_name} - #{p.open_on.year}" => p.id } }.reduce({}, :update)
   end
 
   def works_for_select
     works = ProductionCredits::Work.order(:title)
-    works.map {|w| { w.title => w.id } }.reduce({}, :update)
+    works.map { |w| { w.title => w.id } }.reduce({}, :update)
   end
 
   def venues_for_select
     venues = ProductionCredits::Venue.order(:name)
-    venues.map {|v| { v.name => v.id } }.reduce({}, :update)
+    venues.map { |v| { v.name => v.id } }.reduce({}, :update)
   end
 
   def event_types_for_select

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -24,6 +24,12 @@ class GenericFile < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  property :event_type_id, multiple: false
+
+  property :event_type_name, multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   property :curated, multiple: false do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/models/updates_production_credits.rb
+++ b/app/models/updates_production_credits.rb
@@ -11,6 +11,7 @@ class UpdatesProductionCredits
     update_productions
     update_venues
     update_works
+    update_event_type
   end
 
   private
@@ -28,6 +29,10 @@ class UpdatesProductionCredits
   def update_works
     generic_file.work_ids = works.map(&:id).compact.map(&:to_s)
     generic_file.work_names = works.map(&:title).compact
+  end
+
+  def update_event_type
+    generic_file.event_type_name = event_type.try(:name)
   end
 
   def productions
@@ -49,5 +54,10 @@ class UpdatesProductionCredits
       ids = generic_file.work_ids || []
       (ids.any? ? ProductionCredits::Work.find(ids) : productions.map(&:work)).compact
     end
+  end
+
+  def event_type
+    id = generic_file.event_type_id
+    ProductionCredits::EventType.find(id) unless id.blank?
   end
 end

--- a/app/presenters/generic_file_presenter.rb
+++ b/app/presenters/generic_file_presenter.rb
@@ -15,11 +15,12 @@ class GenericFilePresenter < Sufia::GenericFilePresenter
     :related_url,
     :production_ids,
     :venue_ids,
+    :event_type_id,
     :curated
   ]
 
   # Names are not displayed directly so don't include them in `terms'.
-  delegate :production_names, :venue_names, to: :model
+  delegate :production_names, :venue_names, :event_type_name, to: :model
 
   delegate :public?, :discoverable?, :restricted?, :private?, to: :model
 end

--- a/app/views/records/edit_fields/_event_type_id.html.erb
+++ b/app/views/records/edit_fields/_event_type_id.html.erb
@@ -1,0 +1,6 @@
+<%= f.input :event_type_id,
+      label: "Event Type",
+      as: :select_with_help,
+      collection: event_types_for_select,
+      input_html: { class: 'form-control' }
+%>

--- a/app/views/records/show_fields/_event_type_id.html.erb
+++ b/app/views/records/show_fields/_event_type_id.html.erb
@@ -1,0 +1,1 @@
+<%= record.event_type_name %>

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -15,10 +15,12 @@ describe GenericFilesController do
                     work: nil)
   end
   let(:venue) { instance_double(ProductionCredits::Venue, id: 2, name: "The Venue") }
+  let(:event_type) { instance_double(ProductionCredits::EventType, id: 3, name: "The Event") }
   let(:attributes) do
     {
       production_ids: [production.id],
-      venue_ids: [venue.id]
+      venue_ids: [venue.id],
+      event_type_id: event_type.id
     }
   end
   let(:reloaded) { generic_file.reload }
@@ -29,6 +31,7 @@ describe GenericFilesController do
     allow(ProductionCredits::Production).to receive(:find).with([]) { [] }
     allow(ProductionCredits::Venue).to receive(:find).with([venue.id.to_s]) { [venue] }
     allow(ProductionCredits::Venue).to receive(:find).with([]) { [] }
+    allow(ProductionCredits::EventType).to receive(:find).with(event_type.id.to_s) { event_type }
     sign_in user
     post :update, id: generic_file, generic_file: attributes
   end
@@ -36,10 +39,12 @@ describe GenericFilesController do
   it "persists the ids" do
     expect(reloaded.production_ids).to eq [production.id.to_s]
     expect(reloaded.venue_ids).to eq [venue.id.to_s]
+    expect(reloaded.event_type_id).to eq event_type.id.to_s
   end
 
   it "finds and persists the names" do
     expect(reloaded.production_names).to eq [production.production_name]
     expect(reloaded.venue_names).to eq [venue.name]
+    expect(reloaded.event_type_name).to eq event_type.name
   end
 end

--- a/spec/models/updates_production_credits_spec.rb
+++ b/spec/models/updates_production_credits_spec.rb
@@ -13,6 +13,7 @@ describe UpdatesProductionCredits do
   let(:venue) { instance_double(ProductionCredits::Venue, id: 58, name: "VENUE") }
   let(:work) { instance_double(ProductionCredits::Work, id: 123, title: "WORK") }
   let(:production_work) { instance_double(ProductionCredits::Work, id: 443, title: "PRODUCTION WORK") }
+  let(:event_type) { instance_double(ProductionCredits::EventType, id: 254, name: "EVENT") }
 
   before do
     allow(ProductionCredits::Production).to receive(:find).with([production.id]) { [production] }
@@ -21,6 +22,7 @@ describe UpdatesProductionCredits do
     allow(ProductionCredits::Work).to receive(:find).with([]) { [] }
     allow(ProductionCredits::Venue).to receive(:find).with([venue.id]) { [venue] }
     allow(ProductionCredits::Venue).to receive(:find).with([]) { [] }
+    allow(ProductionCredits::EventType).to receive(:find).with(event_type.id) { event_type }
   end
 
   describe "associated production" do
@@ -151,6 +153,43 @@ describe UpdatesProductionCredits do
 
       it "clears the venue names" do
         expect(file.venue_names).to be_empty
+      end
+    end
+  end
+
+  describe "associated event type" do
+    context "when there is an event type id" do
+      before do
+        file.event_type_id = event_type.id
+        subject.update
+      end
+
+      it "sets the event type name" do
+        expect(file.event_type_name).to eq event_type.name
+      end
+    end
+
+    context "when there isn't an event type id" do
+      before do
+        file.event_type_id = ""
+        file.event_type_name = "EVENT"
+        subject.update
+      end
+
+      it "clears the event type name" do
+        expect(file.event_type_name).to be_nil
+      end
+    end
+
+    context "when event type id is nil" do
+      before do
+        file.event_type_id = nil
+        file.event_type_name = "EVENT"
+        subject.update
+      end
+
+      it "clears the event type name" do
+        expect(file.event_type_name).to be_nil
       end
     end
   end


### PR DESCRIPTION
- Add singular event_type_{id,name} properties to GenericFile
- Update event_type_name when saving files
- Make event_type_name searchable in Solr

I had to override more batch edit behavior to allow for nil singular
properties.  The logic in `initialize_fields` that replaces empty
arrays with an array with an empty string doesn’t seem to be necessary,
and makes singular properties blow up, so I’ve eliminated that.
