### PR TITLE
Venue aliases

### DIFF
--- a/app/helpers/generic_file_production_helper.rb
+++ b/app/helpers/generic_file_production_helper.rb
@@ -11,7 +11,7 @@ module GenericFileProductionHelper
 
   def venues_for_select
     venues = ProductionCredits::Venue.order(:name)
-    venues.map { |v| { v.name => v.id } }.reduce({}, :update)
+    venues.map { |v| { v.full_name => v.id } }.reduce({}, :update)
   end
 
   def event_types_for_select

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -18,6 +18,8 @@ class GenericFile < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  property :venue_full_names, multiple: true
+
   property :work_ids, multiple: true
 
   property :work_names, multiple: true do |index|

--- a/app/models/updates_production_credits.rb
+++ b/app/models/updates_production_credits.rb
@@ -23,7 +23,7 @@ class UpdatesProductionCredits
   end
 
   def update_venues
-    generic_file.venue_names = venues.map(&:name).compact
+    generic_file.venue_names = venues.flat_map(&:all_names).compact
   end
 
   def update_works

--- a/app/models/updates_production_credits.rb
+++ b/app/models/updates_production_credits.rb
@@ -24,6 +24,7 @@ class UpdatesProductionCredits
 
   def update_venues
     generic_file.venue_names = venues.flat_map(&:all_names).compact
+    generic_file.venue_full_names = venues.map(&:full_name).compact
   end
 
   def update_works

--- a/app/presenters/generic_file_presenter.rb
+++ b/app/presenters/generic_file_presenter.rb
@@ -20,7 +20,7 @@ class GenericFilePresenter < Sufia::GenericFilePresenter
   ]
 
   # Names are not displayed directly so don't include them in `terms'.
-  delegate :production_names, :venue_names, :event_type_name, to: :model
+  delegate :production_names, :venue_names, :venue_full_names, :event_type_name, to: :model
 
   delegate :public?, :discoverable?, :restricted?, :private?, to: :model
 end

--- a/app/views/records/show_fields/_venue_ids.html.erb
+++ b/app/views/records/show_fields/_venue_ids.html.erb
@@ -1,4 +1,4 @@
-<% record.venue_names.each do |name| %>
+<% record.venue_full_names.each do |name| %>
   <%= name %>
   <br />
 <% end %>

--- a/app/views/searches/_images.html.erb
+++ b/app/views/searches/_images.html.erb
@@ -45,7 +45,7 @@
               <figcaption>
                 <h3><%= image.title.first %></h3>
                 <p><%= image.production_names.join(", ") %></p>
-                <p><%= image.venue_names.join(", ") %></p>
+                <p><%= image.venue_full_names.join(", ") %></p>
                 <p><%= image.description.first %></p>
                 <p><%= formatted_creation_date(image) %></p>
               </figcaption>

--- a/app/views/searches/_videos.html.erb
+++ b/app/views/searches/_videos.html.erb
@@ -10,7 +10,7 @@
     <% @videos.files.each do |video| %>
       <li class="js-video-container card-container">
         <a class="js-video card card--has-img card--overlay-content" data-webm=<%= sufia.download_path(video, datastream_id: 'webm') %> data-mp4=<%= sufia.download_path(video, datastream_id: 'mp4') %> data-title=<%= video.title.first %>
-           data-description=<%= video.description %> data-description=<%= video.venue_names %>>
+           data-description=<%= video.description %> data-description=<%= video.venue_full_names %>>
            <div class="card-figure-img">
               <div class="card-figure-img-wrapper">
                 <img src="<%= sufia.download_path(video, file: 'thumbnail') %>" alt="<%= video.title.first %>" />
@@ -21,7 +21,7 @@
               <%= video.title.first %>
             </h3>
             <h4 class="card__content_subtitle">
-              <%= video.venue_names.join(", ") %>
+              <%= video.venue_full_names.join(", ") %>
             </h4>
             <p class="card__content__date">
               <%= formatted_creation_date(video) %>

--- a/app/views/searches/images.html.erb
+++ b/app/views/searches/images.html.erb
@@ -27,7 +27,7 @@
       <figcaption>
         <h3><%= image.title.first %></h3>
         <p><%= image.production_names.join(',') %></p>
-        <p><%= image.venue_names.join(',') %></p>
+        <p><%= image.venue_full_names.join(',') %></p>
         <p><%= image.description.first %></p>
         <p><%= formatted_creation_date(image) %></p>
       </figcaption>

--- a/app/views/searches/videos.html.erb
+++ b/app/views/searches/videos.html.erb
@@ -3,7 +3,7 @@
     <% @videos.files.each do |video| %>
       <li class="js-video-container card-container">
         <a class="js-video card card--has-img card--overlay-content" data-webm=<%= sufia.download_path(video, datastream_id: 'webm') %> data-mp4=<%= sufia.download_path(video, datastream_id: 'mp4') %> data-title=<%= video.title.first %>
-           data-description=<%= video.description %> data-description=<%= video.venue_names %>>
+           data-description=<%= video.description %> data-description=<%= video.venue_full_names %>>
            <div class="card-figure-img">
               <div class="card-figure-img-wrapper">
                 <img src="<%= sufia.download_path(video, file: 'thumbnail') %>" alt="<%= video.title.first %>" />
@@ -14,7 +14,7 @@
               <%= video.title.first %>
             </h3>
             <h4 class="card__content_subtitle">
-              <%= video.venue_names %>
+              <%= video.venue_full_names %>
             </h4>
             <p class="card__content__date">
               <%= formatted_creation_date(video) %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150925002801) do
+ActiveRecord::Schema.define(version: 20150928185120) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -186,7 +186,6 @@ ActiveRecord::Schema.define(version: 20150925002801) do
     t.date    "open_on"
     t.date    "close_on"
     t.integer "work_id"
-    t.string  "venue_alias"
   end
 
   add_index "production_credits_productions", ["work_id"], name: "index_production_credits_productions_on_work_id"
@@ -203,7 +202,10 @@ ActiveRecord::Schema.define(version: 20150925002801) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "canonical_venue_id"
   end
+
+  add_index "production_credits_venues", ["canonical_venue_id"], name: "index_production_credits_venues_on_canonical_venue_id"
 
   create_table "production_credits_works", force: :cascade do |t|
     t.string   "title"

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -14,7 +14,7 @@ describe GenericFilesController do
                     production_name: "The Production",
                     work: nil)
   end
-  let(:venue) { instance_double(ProductionCredits::Venue, id: 2, all_names: ["The Venue"]) }
+  let(:venue) { instance_double(ProductionCredits::Venue, id: 2, full_name: "The Venue", all_names: ["The Venue"]) }
   let(:event_type) { instance_double(ProductionCredits::EventType, id: 3, name: "The Event") }
   let(:attributes) do
     {
@@ -45,6 +45,7 @@ describe GenericFilesController do
   it "finds and persists the names" do
     expect(reloaded.production_names).to eq [production.production_name]
     expect(reloaded.venue_names).to eq venue.all_names
+    expect(reloaded.venue_full_names).to eq [venue.full_name]
     expect(reloaded.event_type_name).to eq event_type.name
   end
 end

--- a/spec/controllers/generic_files_controller_spec.rb
+++ b/spec/controllers/generic_files_controller_spec.rb
@@ -14,7 +14,7 @@ describe GenericFilesController do
                     production_name: "The Production",
                     work: nil)
   end
-  let(:venue) { instance_double(ProductionCredits::Venue, id: 2, name: "The Venue") }
+  let(:venue) { instance_double(ProductionCredits::Venue, id: 2, all_names: ["The Venue"]) }
   let(:event_type) { instance_double(ProductionCredits::EventType, id: 3, name: "The Event") }
   let(:attributes) do
     {
@@ -44,7 +44,7 @@ describe GenericFilesController do
 
   it "finds and persists the names" do
     expect(reloaded.production_names).to eq [production.production_name]
-    expect(reloaded.venue_names).to eq [venue.name]
+    expect(reloaded.venue_names).to eq venue.all_names
     expect(reloaded.event_type_name).to eq event_type.name
   end
 end

--- a/spec/models/updates_production_credits_spec.rb
+++ b/spec/models/updates_production_credits_spec.rb
@@ -10,7 +10,7 @@ describe UpdatesProductionCredits do
                     work: production_work
     )
   end
-  let(:venue) { instance_double(ProductionCredits::Venue, id: 58, all_names: %w[ALIAS VENUE]) }
+  let(:venue) { instance_double(ProductionCredits::Venue, id: 58, full_name: "ALIAS (VENUE)", all_names: %w[ALIAS VENUE]) }
   let(:work) { instance_double(ProductionCredits::Work, id: 123, title: "WORK") }
   let(:production_work) { instance_double(ProductionCredits::Work, id: 443, title: "PRODUCTION WORK") }
   let(:event_type) { instance_double(ProductionCredits::EventType, id: 254, name: "EVENT") }
@@ -130,6 +130,10 @@ describe UpdatesProductionCredits do
       it "sets the venue names" do
         expect(file.venue_names).to eq venue.all_names
       end
+
+      it "sets the venue full names" do
+        expect(file.venue_full_names).to eq [venue.full_name]
+      end
     end
 
     context "when there aren't venue_ids" do
@@ -139,8 +143,12 @@ describe UpdatesProductionCredits do
         subject.update
       end
 
-      it "clears the venue name" do
+      it "clears the venue names" do
         expect(file.venue_names).to be_empty
+      end
+
+      it "clears the venue full names" do
+        expect(file.venue_full_names).to be_empty
       end
     end
 
@@ -153,6 +161,10 @@ describe UpdatesProductionCredits do
 
       it "clears the venue names" do
         expect(file.venue_names).to be_empty
+      end
+
+      it "clears the venue full names" do
+        expect(file.venue_full_names).to be_empty
       end
     end
   end

--- a/spec/models/updates_production_credits_spec.rb
+++ b/spec/models/updates_production_credits_spec.rb
@@ -10,7 +10,7 @@ describe UpdatesProductionCredits do
                     work: production_work
     )
   end
-  let(:venue) { instance_double(ProductionCredits::Venue, id: 58, name: "VENUE") }
+  let(:venue) { instance_double(ProductionCredits::Venue, id: 58, all_names: %w[ALIAS VENUE]) }
   let(:work) { instance_double(ProductionCredits::Work, id: 123, title: "WORK") }
   let(:production_work) { instance_double(ProductionCredits::Work, id: 443, title: "PRODUCTION WORK") }
   let(:event_type) { instance_double(ProductionCredits::EventType, id: 254, name: "EVENT") }
@@ -128,7 +128,7 @@ describe UpdatesProductionCredits do
       end
 
       it "sets the venue names" do
-        expect(file.venue_names).to eq [venue.name]
+        expect(file.venue_names).to eq venue.all_names
       end
     end
 

--- a/vendor/engines/production_credits/app/models/concerns/production_credits/venue_admin.rb
+++ b/vendor/engines/production_credits/app/models/concerns/production_credits/venue_admin.rb
@@ -1,0 +1,24 @@
+module ProductionCredits
+  module VenueAdmin
+    extend ActiveSupport::Concern
+
+    included do
+      rails_admin do
+        list do
+          sort_by :name
+        end
+        object_label_method :full_name
+
+        configure :canonical_venue do
+          associated_collection_scope do
+            Proc.new { |scope| scope.canonical }
+          end
+        end
+
+        configure :aliases do
+          hide
+        end
+      end
+    end
+  end
+end

--- a/vendor/engines/production_credits/app/models/production_credits/venue.rb
+++ b/vendor/engines/production_credits/app/models/production_credits/venue.rb
@@ -41,8 +41,8 @@ module ProductionCredits
     end
 
     def alias_cannot_have_aliases
-      if aliases.any?
-        errors.add(:base, "A venue with aliases if its own cannot be an alias")
+      if alias? && aliases.any?
+        errors.add(:base, "A venue with aliases of its own cannot be an alias")
       end
     end
   end

--- a/vendor/engines/production_credits/app/models/production_credits/venue.rb
+++ b/vendor/engines/production_credits/app/models/production_credits/venue.rb
@@ -1,17 +1,12 @@
 module ProductionCredits
   class Venue < ActiveRecord::Base
-    has_and_belongs_to_many :productions
     validates_presence_of :name
 
+    belongs_to :canonical_venue, class_name: Venue
+    has_and_belongs_to_many :productions
 
-    def self.find_by_name_or_alias(name)
-      venue_name = name.scan(/\(([^\)]+)\)/)
-      if venue_name.empty?
-        venue_name = name
-      else
-        venue_name = venue_name.last.first
-      end
-      ProductionCredits::Venue.where(name: venue_name).first
+    def full_name
+      canonical_venue ? "#{name} (#{canonical_venue.name})" : name
     end
   end
 end

--- a/vendor/engines/production_credits/app/models/production_credits/venue.rb
+++ b/vendor/engines/production_credits/app/models/production_credits/venue.rb
@@ -1,8 +1,15 @@
 module ProductionCredits
   class Venue < ActiveRecord::Base
     validates_presence_of :name
+    validate :canonical_venue_cannot_be_an_alias,
+             :alias_cannot_have_aliases
 
     belongs_to :canonical_venue, class_name: Venue
+    has_many :aliases,
+             class_name: Venue,
+             dependent: :nullify,
+             foreign_key: :canonical_venue_id,
+             inverse_of: :canonical_venue
     has_and_belongs_to_many :productions
 
     def full_name
@@ -15,6 +22,28 @@ module ProductionCredits
 
     def canonical_name
       canonical_venue.try(:name)
+    end
+
+    def canonical?
+      canonical_venue_id.nil?
+    end
+
+    def alias?
+      !canonical?
+    end
+
+    private
+
+    def canonical_venue_cannot_be_an_alias
+      if canonical_venue && canonical_venue.alias?
+        errors.add(:canonical_venue, "cannot be an alias of another venue")
+      end
+    end
+
+    def alias_cannot_have_aliases
+      if aliases.any?
+        errors.add(:base, "A venue with aliases if its own cannot be an alias")
+      end
     end
   end
 end

--- a/vendor/engines/production_credits/app/models/production_credits/venue.rb
+++ b/vendor/engines/production_credits/app/models/production_credits/venue.rb
@@ -6,7 +6,15 @@ module ProductionCredits
     has_and_belongs_to_many :productions
 
     def full_name
-      canonical_venue ? "#{name} (#{canonical_venue.name})" : name
+      canonical_name ? "#{name} (#{canonical_name})" : name
+    end
+
+    def all_names
+      [name, canonical_name].compact
+    end
+
+    def canonical_name
+      canonical_venue.try(:name)
     end
   end
 end

--- a/vendor/engines/production_credits/app/models/production_credits/venue.rb
+++ b/vendor/engines/production_credits/app/models/production_credits/venue.rb
@@ -1,10 +1,14 @@
 module ProductionCredits
   class Venue < ActiveRecord::Base
+    include VenueAdmin
+
+    scope :canonical, -> { where(canonical_venue_id: nil) }
+
     validates_presence_of :name
     validate :canonical_venue_cannot_be_an_alias,
              :alias_cannot_have_aliases
 
-    belongs_to :canonical_venue, class_name: Venue
+    belongs_to :canonical_venue, class_name: Venue, inverse_of: :aliases
     has_many :aliases,
              class_name: Venue,
              dependent: :nullify,

--- a/vendor/engines/production_credits/db/migrate/20150928182300_add_canonical_venue_id_to_production_credits_venues.rb
+++ b/vendor/engines/production_credits/db/migrate/20150928182300_add_canonical_venue_id_to_production_credits_venues.rb
@@ -1,0 +1,5 @@
+class AddCanonicalVenueIdToProductionCreditsVenues < ActiveRecord::Migration
+  def change
+    add_reference :production_credits_venues, :canonical_venue, references: :venues, index: true
+  end
+end

--- a/vendor/engines/production_credits/db/migrate/20150928185120_remove_venue_alias_from_production_credits_productions.rb
+++ b/vendor/engines/production_credits/db/migrate/20150928185120_remove_venue_alias_from_production_credits_productions.rb
@@ -1,0 +1,5 @@
+class RemoveVenueAliasFromProductionCreditsProductions < ActiveRecord::Migration
+  def change
+    remove_column :production_credits_productions, :venue_alias, :string
+  end
+end

--- a/vendor/engines/production_credits/spec/dummy/db/schema.rb
+++ b/vendor/engines/production_credits/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150925002801) do
+ActiveRecord::Schema.define(version: 20150928185120) do
 
   create_table "production_credits_event_types", force: :cascade do |t|
     t.string   "name"
@@ -25,7 +25,6 @@ ActiveRecord::Schema.define(version: 20150925002801) do
     t.date    "open_on"
     t.date    "close_on"
     t.integer "work_id"
-    t.string  "venue_alias"
   end
 
   add_index "production_credits_productions", ["work_id"], name: "index_production_credits_productions_on_work_id"
@@ -42,7 +41,10 @@ ActiveRecord::Schema.define(version: 20150925002801) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "canonical_venue_id"
   end
+
+  add_index "production_credits_venues", ["canonical_venue_id"], name: "index_production_credits_venues_on_canonical_venue_id"
 
   create_table "production_credits_works", force: :cascade do |t|
     t.string   "title"

--- a/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
+++ b/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
@@ -22,5 +22,23 @@ module ProductionCredits
         end
       end
     end
+
+    describe "all names" do
+      context "with a canonical venue" do
+        let(:venue) { canonical_venue }
+
+        it "includes only its own name" do
+          expect(venue.all_names).to eq [venue.name]
+        end
+      end
+
+      context "with an alias" do
+        let(:venue) { alias_venue }
+
+        it "includes its own name and its canonical name" do
+          expect(venue.all_names).to include(venue.name, canonical_venue.name)
+        end
+      end
+    end
   end
 end

--- a/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
+++ b/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
@@ -6,7 +6,7 @@ module ProductionCredits
     let!(:alias_venue) { Venue.create!(name: "Alias", canonical_venue: canonical_venue) }
 
     describe "alias validation" do
-      context "with a canonical venue" do
+      context "when adding an alias to a canonical venue" do
         let(:venue) { canonical_venue }
         let!(:new_alias) { Venue.create!(name: "New Alias") }
 
@@ -14,12 +14,16 @@ module ProductionCredits
           new_alias.canonical_venue = venue
         end
 
-        it "is valid" do
+        specify "the alias is valid" do
           expect(new_alias).to be_valid
+        end
+
+        specify "the canonical venue is valid" do
+          expect(venue).to be_valid
         end
       end
 
-      context "with an alias" do
+      context "when adding an alias to an alias" do
         let(:venue) { alias_venue }
         let(:new_alias) { Venue.create!(name: "New Alias") }
 
@@ -32,7 +36,7 @@ module ProductionCredits
         end
       end
 
-      context "with a venue that has aliases" do
+      context "when adding a venue with aliases as an alias" do
         let(:venue) { canonical_venue }
         let(:new_canonical_venue) { Venue.create!(name: "New Canonical") }
 

--- a/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
+++ b/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
@@ -2,6 +2,25 @@ require 'spec_helper'
 
 module ProductionCredits
   RSpec.describe Venue, :type => :model do
-    it { should have_and_belong_to_many :productions }
+    let(:canonical_venue) { Venue.create(name: "Canonical") }
+    let(:alias_venue) { Venue.create(name: "Alias", canonical_venue: canonical_venue) }
+
+    describe "full name" do
+      context "with a canonical venue" do
+        let(:venue) { canonical_venue }
+
+        it "uses its name as its full name" do
+          expect(venue.full_name).to eq "Canonical"
+        end
+      end
+
+      context "with an alias" do
+        let(:venue) { alias_venue }
+
+        it "constructs a full name from its own name and its canonical name" do
+          expect(venue.full_name).to eq "Alias (Canonical)"
+        end
+      end
+    end
   end
 end

--- a/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
+++ b/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
@@ -48,6 +48,18 @@ module ProductionCredits
           expect(venue).not_to be_valid
         end
       end
+
+      context "adding a venue as an alias of itself" do
+        let(:venue) { Venue.create!(name: "Self Alias") }
+
+        before do
+          venue.canonical_venue = venue
+        end
+
+        it "is not valid" do
+            expect(venue).not_to be_valid
+        end
+      end
     end
 
     describe "deleting a canonical venue" do

--- a/vendor/engines/production_credits/spec/spec_helper.rb
+++ b/vendor/engines/production_credits/spec/spec_helper.rb
@@ -2,7 +2,6 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 
 require 'rspec/rails'
-require 'rspec/autorun'
 require 'factory_girl_rails'
 require 'shoulda/matchers'
 


### PR DESCRIPTION
Allow a venue to be an alias of another venue.  The alias and the “canonical” venue will show up in all select lists.  Aliases include their canonical venue name in parens (using the `full_name` method).

Both the alias name and the canonical venue name are added to the index for generic files.  This allows keyword search by either name, and for the venue name filter to work.  Unfortunately, this means that we would be unable to display a venue’s `full_name` on items in the search results or in the show view in Sufia.  To counteract that, we also store a `venue_full_names` property on the generic files and use that for display.

We customized RailsAdmin to filter the list of venues that can be selected as the canonical venue; venues that are already aliases cannot be canonical - we don’t want chains of aliases.
