### PR TITLE
Show Discoverable badge where missing

### DIFF
--- a/app/helpers/sufia_helper.rb
+++ b/app/helpers/sufia_helper.rb
@@ -2,4 +2,17 @@ module SufiaHelper
   include ::BlacklightHelper
   include Sufia::BlacklightOverride
   include Sufia::SufiaHelperBehavior
+
+  def render_visibility_label(document)
+    case
+    when document.public?
+      content_tag :span, t("sufia.visibility.open"), class: "label label-success", title: t("sufia.visibility.open_title_attr")
+    when document.discoverable?
+      content_tag :span, t("digital_archives.visibility.discoverable"), class: "label label-warning", title: t("digital_archives.visibility.discoverable_title_attr")
+    when document.registered?
+      content_tag :span, t("sufia.institution_name"), class: "label label-info", title: t("sufia.institution_name")
+    else
+      content_tag :span, t("sufia.visibility.private"), class: "label label-danger", title: t("sufia.visibility.private_title_attr")
+    end
+  end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-class SolrDocument 
+class SolrDocument
 
   include Blacklight::Solr::Document
   include Blacklight::Gallery::OpenseadragonSolrDocument
@@ -9,10 +9,10 @@ class SolrDocument
 
 
   # self.unique_key = 'id'
-  
+
   # Email uses the semantic field mappings below to generate the body of an email.
   SolrDocument.use_extension( Blacklight::Document::Email )
-  
+
   # SMS uses the semantic field mappings below to generate the body of an SMS email.
   SolrDocument.use_extension( Blacklight::Document::Sms )
 
@@ -21,10 +21,18 @@ class SolrDocument
   # single valued. See Blacklight::Document::SemanticFields#field_semantics
   # and Blacklight::Document::SemanticFields#to_semantic_values
   # Recommendation: Use field names from Dublin Core
-  use_extension( Blacklight::Document::DublinCore)    
+  use_extension( Blacklight::Document::DublinCore)
 
 
-  # Do content negotiation for AF models. 
+  # Do content negotiation for AF models.
 
   use_extension( Hydra::ContentNegotiation )
+
+  def discoverable?
+    discover_groups.include?("public")
+  end
+
+  def discover_groups
+    Array(self[Hydra.config.permissions.discover.group])
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,7 @@
 
 en:
   hello: "Hello world"
+  digital_archives:
+    visibility:
+      discoverable: "Discoverable"
+      discoverable_title_attr: "Discoverable"


### PR DESCRIPTION
We needed to override the render_visibility_label helper to include
discoverable.

We discovered that, in one use case, the document is actually a
`SolrDocument` and not a `GenericFile`, so we had to add
`discoverable?` and friends to `SolrDocument` in order for this to work.
