### PR TITLE
Use our branch of hydra-head

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,11 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'sufia', github: 'OregonShakespeareFestival/sufia', branch: 'osf_integration'
 gem 'kaminari', github: 'jcoyne/kaminari', branch: 'sufia'
 
+# Use our branch of hydra-access-controls.  This can go away once our PR is
+# merged and we upgrade to the version containing our PR.
+# See https://github.com/projecthydra/hydra-head/pull/287
+gem "hydra-access-controls", github: "OregonShakespeareFestival/hydra-head", branch: "osf_integration"
+
 gem 'production_credits', path: 'vendor/engines/production_credits'
 gem 'rails_admin', github: 'codingzeal/rails_admin', branch: 'sufia-6.2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,26 @@
 GIT
+  remote: git://github.com/OregonShakespeareFestival/hydra-head.git
+  revision: 900127c3135891cb55cbbc899f885d46ac699df5
+  branch: osf_integration
+  specs:
+    hydra-access-controls (9.2.2)
+      active-fedora (~> 9.0)
+      activesupport (~> 4.0)
+      blacklight (~> 5.10)
+      cancancan (~> 1.8)
+      deprecation (~> 0.1)
+      sass-rails
+    hydra-core (9.2.2)
+      active-fedora (~> 9.1)
+      hydra-access-controls (= 9.2.2)
+      jettywrapper (>= 2.0.0)
+      rails (~> 4.0)
+    hydra-head (9.2.2)
+      hydra-access-controls (= 9.2.2)
+      hydra-core (= 9.2.2)
+      rails (>= 3.2.6)
+
+GIT
   remote: git://github.com/OregonShakespeareFestival/sufia.git
   revision: 7c408a89b1a3aaa5d8e466dcba0e8c7418ffbd43
   branch: osf_integration
@@ -308,13 +330,6 @@ GEM
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    hydra-access-controls (9.2.2)
-      active-fedora (~> 9.0)
-      activesupport (~> 4.0)
-      blacklight (~> 5.10)
-      cancancan (~> 1.8)
-      deprecation (~> 0.1)
-      sass-rails
     hydra-batch-edit (1.1.1)
       blacklight
       hydra-collections
@@ -322,11 +337,6 @@ GEM
       blacklight (~> 5.10)
       deprecation (~> 0.1)
       hydra-head (~> 9.1)
-    hydra-core (9.2.2)
-      active-fedora (~> 9.1)
-      hydra-access-controls (= 9.2.2)
-      jettywrapper (>= 2.0.0)
-      rails (~> 4.0)
     hydra-derivatives (1.1.0)
       active-fedora (~> 9.0)
       activesupport (~> 4.0)
@@ -341,10 +351,6 @@ GEM
       simple_form (~> 3.1.0)
     hydra-file_characterization (0.3.2)
       activesupport (>= 3.0.0)
-    hydra-head (9.2.2)
-      hydra-access-controls (= 9.2.2)
-      hydra-core (= 9.2.2)
-      rails (>= 3.2.6)
     i18n (0.7.0)
     jbuilder (2.3.1)
       activesupport (>= 3.0.0, < 5)
@@ -720,6 +726,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.3)
   factory_girl_rails
+  hydra-access-controls!
   jbuilder (~> 2.0)
   jettywrapper
   jquery-rails

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,33 +4,13 @@ class Ability
 
   # Define any customized permissions here.
   def custom_permissions
-    discover_permissions
     override_download_permissions
   end
 
   private
 
-  # TODO: discover_permissions and friends should really be moved into
-  # hydra_access_controls.  We should fork that gem and make the change
-  # there instead, then submit it as a PR.
-  #
-  # override_download_permissions should stay here, but maybe there's a
-  # way to not duplicate the code from hydra_access_controls.
-
-  def discover_permissions
-    can :discover, String do |id|
-      test_discover(id)
-    end
-
-    can :discover, ActiveFedora::Base do |obj|
-      test_discover(obj.id)
-    end
-
-    can :discover, SolrDocument do |obj|
-      cache.put(obj.id, obj)
-      test_discover(obj.id)
-    end
-  end
+  # Maybe there's a way to not duplicate the code from hydra-access-controls
+  # in override_download_permissions.
 
   def override_download_permissions
     can :download, ActiveFedora::File do |file|
@@ -42,38 +22,5 @@ class Ability
         can? :read, parent_id
       end
     end
-  end
-
-  def test_discover(id)
-    Rails.logger.debug("[CANCAN] Checking discover permissions for user: #{current_user.user_key} with groups: #{user_groups.inspect}")
-    group_intersection = user_groups & discover_groups(id)
-    result = !group_intersection.empty? || discover_users(id).include?(current_user.user_key)
-    result
-  end
-
-  # read implies discover, so discover_groups is the union of read and discover groups
-  def discover_groups(id)
-    doc = permissions_doc(id)
-    return [] if doc.nil?
-    dg = read_groups(id) | (doc[self.class.discover_group_field] || [])
-    Rails.logger.debug("[CANCAN] discover_groups: #{dg.inspect}")
-    dg
-  end
-
-  # read implies discover, so discover_users is the union of read and discover users
-  def discover_users(id)
-    doc = permissions_doc(id)
-    return [] if doc.nil?
-    dp = read_users(id) | (doc[self.class.discover_user_field] || [])
-    Rails.logger.debug("[CANCAN] discover_users: #{dp.inspect}")
-    dp
-  end
-
-  def self.discover_group_field
-    Hydra.config.permissions.discover.group
-  end
-
-  def self.discover_user_field
-    Hydra.config.permissions.discover.individual
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -33,6 +33,6 @@ class SolrDocument
   end
 
   def discover_groups
-    Array(self[Hydra.config.permissions.discover.group])
+    Array(self[::Ability.discover_group_field])
   end
 end


### PR DESCRIPTION
We’ve submitted a PR for adding discover abilities to
hydra-access-controls (part of hydra-head).  I made a new branch,
`osf_integration`, off of v9.2.2 and then cherry-picked the PR commit
into that branch.

This commit removes the local versions of the PR code.

It also makes use of one of the methods added as part of the PR in
`solr_document.rb`.  This makes our implementation of `discover_groups`
more like Sufia’s implementation of `read_groups` and friends.
