### PR TITLE
Show placeholders for unreadable items

### DIFF
--- a/app/helpers/generic_file_production_helper.rb
+++ b/app/helpers/generic_file_production_helper.rb
@@ -25,4 +25,8 @@ module GenericFileProductionHelper
 
     date.to_date.to_s(:mdy)
   end
+
+  def unreadable?(file)
+    can?(:discover, file) && cannot?(:read, file)
+  end
 end

--- a/app/views/searches/_article.html.erb
+++ b/app/views/searches/_article.html.erb
@@ -1,0 +1,15 @@
+<li class="card-container">
+  <a class="card card--has-img" target=_blank href=<%= sufia.download_path(article) %>>
+    <div class="card-figure-img">
+      <img src="<%= sufia.download_path(article, file: 'thumbnail') %>" alt="<%= article.title.first %>">
+    </div>
+    <div class="card-content">
+      <h3 class="card-content-title">
+        <%= article.title.first %>
+      </h3>
+      <h4 class="card-content-subtitle">
+        <%= article.production_names %>
+      </h4>
+    </div>
+  </a>
+</li>

--- a/app/views/searches/_article_unreadable.html.erb
+++ b/app/views/searches/_article_unreadable.html.erb
@@ -1,0 +1,13 @@
+<li class="card-container">
+  <div class="card-figure-img">
+    <%= image_tag "unreadable_item", alt: "Unreadable Item" %>
+  </div>
+  <div class="card-content">
+    <h3 class="card-content-title">
+      <%= article.title.first %>
+    </h3>
+    <h4 class="card-content-subtitle">
+      <%= article.production_names %>
+    </h4>
+  </div>
+</li>

--- a/app/views/searches/_audio.html.erb
+++ b/app/views/searches/_audio.html.erb
@@ -1,0 +1,5 @@
+<li>
+  <audio controls preload="none">
+    <source src="<%= sufia.download_path(audio) %>" />
+  </audio>
+</li>

--- a/app/views/searches/_audio_unreadable.html.erb
+++ b/app/views/searches/_audio_unreadable.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= image_tag "unreadable_item", alt: "Unreadable Item" %>
+</li>

--- a/app/views/searches/_image_slideshow.html.erb
+++ b/app/views/searches/_image_slideshow.html.erb
@@ -1,0 +1,12 @@
+<li>
+  <figure>
+    <img class="slideshow-img" src="<%= sufia.download_path(image) %>" alt="<%= image.title.first %>" />
+    <figcaption>
+      <h3><%= image.title.first %></h3>
+      <p><%= image.production_names.join(',') %></p>
+      <p><%= image.venue_full_names.join(',') %></p>
+      <p><%= image.description.first %></p>
+      <p><%= formatted_creation_date(image) %></p>
+    </figcaption>
+  </figure>
+</li>

--- a/app/views/searches/_image_slideshow.html.erb
+++ b/app/views/searches/_image_slideshow.html.erb
@@ -1,6 +1,10 @@
 <li>
   <figure>
-    <img class="slideshow-img" src="<%= sufia.download_path(image) %>" alt="<%= image.title.first %>" />
+    <% if unreadable?(image) %>
+      <%= image_tag "unreadable_item", alt: "Unreadable Item", class: "slideshow-img" %>
+    <% else %>
+      <%= image_tag sufia.download_path(image), alt: image.title.first, class: "slideshow-img" %>
+    <% end %>
     <figcaption>
       <h3><%= image.title.first %></h3>
       <p><%= image.production_names.join(',') %></p>

--- a/app/views/searches/_image_thumbnail.html.erb
+++ b/app/views/searches/_image_thumbnail.html.erb
@@ -1,0 +1,15 @@
+<li class="card-container">
+  <a class="card card--has-image card--overlay-content">
+    <figure class="card__figure">
+      <img class="card__figure__image" src="<%= sufia.download_path(image, file: 'thumbnail') %>" alt="<%= image.title.first %>" />
+    </figure>
+    <div class="card__content">
+      <h1 class="card__content__title">
+        <%= image.title.first %>
+      </h1>
+      <p class="card__content__date">
+        <%= formatted_creation_date(image) %>
+      </p>
+    </div>
+  </a>
+</li>

--- a/app/views/searches/_video.html.erb
+++ b/app/views/searches/_video.html.erb
@@ -1,0 +1,21 @@
+<li class="js-video-container card-container">
+  <a class="js-video card card--has-img card--overlay-content" data-webm=<%= sufia.download_path(video, datastream_id: 'webm') %> data-mp4=<%= sufia.download_path(video, datastream_id: 'mp4') %> data-title=<%= video.title.first %>
+     data-description=<%= video.description %> data-description=<%= video.venue_full_names %>>
+     <div class="card-figure-img">
+        <div class="card-figure-img-wrapper">
+          <img src="<%= sufia.download_path(video, file: 'thumbnail') %>" alt="<%= video.title.first %>" />
+        </div>
+      </div>
+    <div class="card__content">
+      <h3 class="card__content__title">
+        <%= video.title.first %>
+      </h3>
+      <h4 class="card__content_subtitle">
+        <%= video.venue_full_names %>
+      </h4>
+      <p class="card__content__date">
+        <%= formatted_creation_date(video) %>
+      </p>
+    </div>
+  </a>
+</li>

--- a/app/views/searches/_video_unreadable.html.erb
+++ b/app/views/searches/_video_unreadable.html.erb
@@ -1,0 +1,19 @@
+<li class="js-video-container card-container">
+  <div class="card-figure-img">
+    <div class="card-figure-img-wrapper">
+      <!-- <img src="<%= sufia.download_path(video, file: 'thumbnail') %>" alt="<%= video.title.first %>" /> -->
+      <%= image_tag "unreadable_item", alt: "Unreadable Item" %>
+    </div>
+  </div>
+  <div class="card__content">
+    <h3 class="card__content__title">
+      <%= video.title.first %>
+    </h3>
+    <h4 class="card__content_subtitle">
+      <%= video.venue_full_names %>
+    </h4>
+    <p class="card__content__date">
+      <%= formatted_creation_date(video) %>
+    </p>
+  </div>
+</li>

--- a/app/views/searches/articles.html.erb
+++ b/app/views/searches/articles.html.erb
@@ -1,7 +1,11 @@
 <div data-page="<%= @articles.next_page %>" data-more="<%= @articles.show_more? %>">
   <div id="articles">
     <% @articles.files.each do |article| %>
-      <%= render partial: "article", object: article %>
+      <% if unreadable?(article) %>
+        <%= render partial: "article_unreadable", locals: { article: article } %>
+      <% else %>
+        <%= render partial: "article", object: article %>
+      <% end %>
     <% end %>
   </div>
 

--- a/app/views/searches/articles.html.erb
+++ b/app/views/searches/articles.html.erb
@@ -4,7 +4,7 @@
       <% if unreadable?(article) %>
         <%= render partial: "article_unreadable", locals: { article: article } %>
       <% else %>
-        <%= render partial: "article", object: article %>
+        <%= render partial: "article", locals: { article: article } %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/searches/articles.html.erb
+++ b/app/views/searches/articles.html.erb
@@ -1,21 +1,7 @@
 <div data-page="<%= @articles.next_page %>" data-more="<%= @articles.show_more? %>">
   <div id="articles">
     <% @articles.files.each do |article| %>
-      <li class="card-container">
-        <a class="card card--has-img" target=_blank href=<%= sufia.download_path(article) %>>
-          <div class="card-figure-img">
-            <img src="<%= sufia.download_path(article, file: 'thumbnail') %>" alt="<%= article.title.first %>">
-          </div>
-          <div class="card-content">
-            <h3 class="card-content-title">
-              <%= article.title.first %>
-            </h3>
-            <h4 class="card-content-subtitle">
-              <%= article.production_names %>
-            </h4>
-          </div>
-        </a>
-      </li>
+      <%= render partial: "article", object: article %>
     <% end %>
   </div>
 

--- a/app/views/searches/audios.html.erb
+++ b/app/views/searches/audios.html.erb
@@ -1,14 +1,10 @@
 <div data-page="<%= @audios.next_page %>" data-more="<%= @audios.show_more? %>">
   <div id="audios">
     <% @audios.files.each do |audio| %>
-    <li>
-      <audio controls preload="none">
-        <source src="<%= sufia.download_path(audio) %>" />
-      </audio>
-    </li>
+      <%= render partial: "audio", object: audio %>
     <% end %>
   </div>
-  
+
   <div class="paging">
     <% if @audios.show_more? %>
     <a href="#" class="js-load-more-audios" data-page="<%= @audios.next_page %>">Load More</a>

--- a/app/views/searches/audios.html.erb
+++ b/app/views/searches/audios.html.erb
@@ -4,7 +4,7 @@
       <% if unreadable?(audio) %>
         <%= render partial: "audio_unreadable", locals: { audio: audio } %>
       <% else %>
-        <%= render partial: "audio", object: audio %>
+        <%= render partial: "audio", locals: { audio: audio } %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/searches/audios.html.erb
+++ b/app/views/searches/audios.html.erb
@@ -1,7 +1,11 @@
 <div data-page="<%= @audios.next_page %>" data-more="<%= @audios.show_more? %>">
   <div id="audios">
     <% @audios.files.each do |audio| %>
-      <%= render partial: "audio", object: audio %>
+      <% if unreadable?(audio) %>
+        <%= render partial: "audio_unreadable", locals: { audio: audio } %>
+      <% else %>
+        <%= render partial: "audio", object: audio %>
+      <% end %>
     <% end %>
   </div>
 

--- a/app/views/searches/images.html.erb
+++ b/app/views/searches/images.html.erb
@@ -1,38 +1,13 @@
 <div data-page="<%= @images.next_page %>" data-more="<%= @images.show_more? %>" data-total-items="<%= @images.total_items %>">
   <ul id="thumbnails">
   <% @images.files.each do |image| %>
-  <li class="card-container">
-    <a class="card card--has-image card--overlay-content">
-      <figure class="card__figure">
-        <img class="card__figure__image" src="<%= sufia.download_path(image, file: 'thumbnail') %>" alt="<%= image.title.first %>" />
-      </figure>
-      <div class="card__content">
-        <h1 class="card__content__title">
-          <%= image.title.first %>
-        </h1>
-        <p class="card__content__date">
-          <%= formatted_creation_date(image) %>
-        </p>
-      </div>
-    </a>
-  </li>
+    <%= render partial: "image_thumbnail", locals: { image: image } %>
   <% end %>
   </ul>
 
   <ul id="slideshow">
   <% @images.files.each do |image| %>
-  <li>
-    <figure>
-      <img class="slideshow-img" src="<%= sufia.download_path(image) %>" alt="<%= image.title.first %>" />
-      <figcaption>
-        <h3><%= image.title.first %></h3>
-        <p><%= image.production_names.join(',') %></p>
-        <p><%= image.venue_full_names.join(',') %></p>
-        <p><%= image.description.first %></p>
-        <p><%= formatted_creation_date(image) %></p>
-      </figcaption>
-    </figure>
-  </li>
+    <%= render partial: "image_slideshow", locals: { image: image } %>
   <% end %>
   </ul>
 

--- a/app/views/searches/videos.html.erb
+++ b/app/views/searches/videos.html.erb
@@ -1,7 +1,7 @@
 <div data-page="<%= @videos.next_page %>" data-more="<%= @videos.show_more? %>">
   <div id="videos">
     <% @videos.files.each do |video| %>
-      <%= render partial: "video", object: video %>
+      <%= render partial: "video", locals: { video: video } %>
     <% end %>
   </div>
 

--- a/app/views/searches/videos.html.erb
+++ b/app/views/searches/videos.html.erb
@@ -1,27 +1,7 @@
 <div data-page="<%= @videos.next_page %>" data-more="<%= @videos.show_more? %>">
   <div id="videos">
     <% @videos.files.each do |video| %>
-      <li class="js-video-container card-container">
-        <a class="js-video card card--has-img card--overlay-content" data-webm=<%= sufia.download_path(video, datastream_id: 'webm') %> data-mp4=<%= sufia.download_path(video, datastream_id: 'mp4') %> data-title=<%= video.title.first %>
-           data-description=<%= video.description %> data-description=<%= video.venue_full_names %>>
-           <div class="card-figure-img">
-              <div class="card-figure-img-wrapper">
-                <img src="<%= sufia.download_path(video, file: 'thumbnail') %>" alt="<%= video.title.first %>" />
-              </div>
-            </div>
-          <div class="card__content">
-            <h3 class="card__content__title">
-              <%= video.title.first %>
-            </h3>
-            <h4 class="card__content_subtitle">
-              <%= video.venue_full_names %>
-            </h4>
-            <p class="card__content__date">
-              <%= formatted_creation_date(video) %>
-            </p>
-          </div>
-        </a>
-      </li>
+      <%= render partial: "video", object: video %>
     <% end %>
   </div>
 

--- a/app/views/searches/videos.html.erb
+++ b/app/views/searches/videos.html.erb
@@ -1,7 +1,11 @@
 <div data-page="<%= @videos.next_page %>" data-more="<%= @videos.show_more? %>">
   <div id="videos">
     <% @videos.files.each do |video| %>
-      <%= render partial: "video", locals: { video: video } %>
+      <% if unreadable?(video) %>
+        <%= render partial: "video_unreadable", locals: { video: video } %>
+      <% else %>
+        <%= render partial: "video", locals: { video: video } %>
+      <% end %>
     <% end %>
   </div>
 


### PR DESCRIPTION
Some items are shown in the search results, but cannot be viewed/downloaded due to copyright issues.

For these items, we show a placeholder image instead, advising the user to contact OSF.

The actual placeholder image will be added later.  Some styllng work is needed as well.
