### PR TITLE
Override Sufia's file size limits

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,3 +17,4 @@
 //= require blacklight/blacklight
 
 //= require sufia
+//= require ./sufia_overrides

--- a/app/assets/javascripts/sufia_overrides.js
+++ b/app/assets/javascripts/sufia_overrides.js
@@ -1,0 +1,6 @@
+// These variables override those defined in Sufia's uploader.js.
+// application.js makes sure that this file is loaded after Sufia.
+var max_file_size = 4000000000;
+var max_file_size_str = "4 GB";
+var max_total_file_size = 4000000000;
+var max_total_file_size_str = "4 GB";


### PR DESCRIPTION
We set the limits for both individual file size and total file size to
4GB, which is the inherent limit of the jQuery file uploader.

Sofia doesn’t provide a configuration point for these, but does make
them global variables on the window, so we load our own overrides of
these values after loading Sufia’s JS assets.
