### PR TITLE
Filter venues based on production selections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ group :development, :test do
   gem 'jettywrapper'
   gem "capybara"
   gem "factory_girl_rails"
+  gem "faker", "~> 1.5"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faker (1.5.0)
+      i18n (~> 0.5)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
@@ -730,6 +732,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.3)
   factory_girl_rails
+  faker (~> 1.5)
   hydra-access-controls!
   jbuilder (~> 2.0)
   jettywrapper

--- a/app/assets/javascripts/sufia_customization/widgets.js.coffee
+++ b/app/assets/javascripts/sufia_customization/widgets.js.coffee
@@ -2,18 +2,22 @@
 
 class @SufiaCustomizations.Initialize
   constructor: ->
+    @_productionIds = $("#generic_file_production_ids")
+    @_venueIds = $("#generic_file_venue_ids")
     @_initializeProductionsSelector()
     @_initializeVenuesSelector()
     @_initializeEventTypeSelector()
 
+    @_hookupVenueSelectionsUpdate()
+
   _initializeProductionsSelector: ->
-    $("#generic_file_production_ids").chosen
+    @_productionIds.chosen
       placeholder_text_multiple: "Select production(s)"
       search_contains: true
       single_backstroke_delete: false
 
   _initializeVenuesSelector: ->
-    $("#generic_file_venue_ids").chosen
+    @_venueIds.chosen
       placeholder_text_multiple: "Select venue(s)"
       search_contains: true
       single_backstroke_delete: false
@@ -24,6 +28,20 @@ class @SufiaCustomizations.Initialize
       allow_single_deselect: true
       search_contains: true
       single_backstroke_delete: false
+
+  _hookupVenueSelectionsUpdate: ->
+    @_productionIds.on "change", @_productionSelectionsChanged
+    @_productionSelectionsChanged()
+
+  _productionSelectionsChanged: =>
+    ids = @_productionIds.val() ? []
+    query = ("production_ids[]=#{id}" for id in ids).join("&")
+    $.get "/production_credits/venues.json?#{query}", @_updateVenueChoiceEnablement
+
+  _updateVenueChoiceEnablement: (venues) =>
+    @_venueIds.find("option").attr "disabled", "disabled"
+    @_venueIds.find("option[value='#{venue.id}']").removeAttr("disabled") for venue in venues
+    @_venueIds.trigger("chosen:updated")
 
 $(document).on 'ready page:load', ->
   new SufiaCustomizations.Initialize()

--- a/app/helpers/generic_file_production_helper.rb
+++ b/app/helpers/generic_file_production_helper.rb
@@ -1,6 +1,6 @@
 module GenericFileProductionHelper
   def productions_for_select
-    productions = ProductionCredits::Production.order(:production_name)
+    productions = ProductionCredits::Production.order(:production_name, open_on: :desc)
     productions.map { |p| { "#{p.production_name} - #{p.open_on.year}" => p.id } }.reduce({}, :update)
   end
 

--- a/spec/models/observers/production_observer_spec.rb
+++ b/spec/models/observers/production_observer_spec.rb
@@ -43,7 +43,7 @@ module Observers
     end
 
     def create_production(name)
-      ProductionCredits::Production.create!(production_name: name, open_on: 2.years.ago, close_on: 1.year.ago)
+      FactoryGirl.create(:production_credits_production, production_name: name)
     end
   end
 end

--- a/vendor/engines/production_credits/Gemfile.lock
+++ b/vendor/engines/production_credits/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faker (1.4.3)
+      i18n (~> 0.5)
     font-awesome-rails (4.4.0.0)
       railties (>= 3.2, < 5.0)
     globalid (0.3.6)
@@ -183,6 +185,7 @@ PLATFORMS
 
 DEPENDENCIES
   factory_girl_rails
+  faker
   production_credits!
   rails_admin!
   rspec-rails

--- a/vendor/engines/production_credits/app/controllers/production_credits/venues_controller.rb
+++ b/vendor/engines/production_credits/app/controllers/production_credits/venues_controller.rb
@@ -4,9 +4,7 @@ module ProductionCredits
     skip_before_filter :authenticate_user!
 
     def index
-      venues = Venue
-        .joins(:productions)
-        .where(production_credits_productions: { id: params[:production_ids] })
+      venues = Venue.for_production_ids(params[:production_ids])
       venues = Venue.all if venues.empty?
       render json: venues, layout: false
     end

--- a/vendor/engines/production_credits/app/controllers/production_credits/venues_controller.rb
+++ b/vendor/engines/production_credits/app/controllers/production_credits/venues_controller.rb
@@ -1,0 +1,14 @@
+module ProductionCredits
+  class VenuesController < ApplicationController
+    skip_before_action :verify_authenticity_token
+    skip_before_filter :authenticate_user!
+
+    def index
+      venues = Venue
+        .joins(:productions)
+        .where(production_credits_productions: { id: params[:production_ids] })
+      venues = Venue.all if venues.empty?
+      render json: venues, layout: false
+    end
+  end
+end

--- a/vendor/engines/production_credits/app/controllers/production_credits/venues_controller.rb
+++ b/vendor/engines/production_credits/app/controllers/production_credits/venues_controller.rb
@@ -4,8 +4,9 @@ module ProductionCredits
     skip_before_filter :authenticate_user!
 
     def index
-      venues = Venue.for_production_ids(params[:production_ids])
-      venues = Venue.all if venues.empty?
+      production_ids = params[:production_ids]
+      venues = Venue.for_production_ids(production_ids) if production_ids
+      venues = Venue.all if venues.blank?
       render json: venues, layout: false
     end
   end

--- a/vendor/engines/production_credits/app/models/production_credits/venue.rb
+++ b/vendor/engines/production_credits/app/models/production_credits/venue.rb
@@ -3,6 +3,9 @@ module ProductionCredits
     include VenueAdmin
 
     scope :canonical, -> { where(canonical_venue_id: nil) }
+    scope :for_production_ids, -> (ids) do
+      joins(:productions).where(production_credits_productions: { id: ids })
+    end
 
     validates_presence_of :name
     validate :canonical_venue_cannot_be_an_alias,

--- a/vendor/engines/production_credits/config/routes.rb
+++ b/vendor/engines/production_credits/config/routes.rb
@@ -2,4 +2,6 @@ ProductionCredits::Engine.routes.draw do
   root to: 'homepage#index'
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   match 'works' => 'works#index', via: [:get, :post]
+
+  resources :venues, only: [:index]
 end

--- a/vendor/engines/production_credits/production_credits.gemspec
+++ b/vendor/engines/production_credits/production_credits.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'shoulda-matchers'
+  s.add_development_dependency "faker"
 end

--- a/vendor/engines/production_credits/spec/controllers/production_credits/venues_controller_spec.rb
+++ b/vendor/engines/production_credits/spec/controllers/production_credits/venues_controller_spec.rb
@@ -5,7 +5,6 @@ module ProductionCredits
     routes { ProductionCredits::Engine.routes }
 
     describe "#index" do
-      let(:params) { { production_ids: ids } }
       let(:ids) { %w[1 2 3] }
       let(:all_venues) { 5.times.map { |n| double(to_json: { name: "VENUE #{n}" }) } }
 
@@ -16,18 +15,31 @@ module ProductionCredits
         get :index, params
       end
 
-      context "when filtered results are found" do
-        let(:filtered_venues) { all_venues.first(2) }
+      context "when production ids are provided" do
+        let(:params) { { production_ids: ids } }
 
-        it "returns filtered venues" do
-          expect(response.body).to eq filtered_venues.to_json
+        context "when filtered results are found" do
+          let(:filtered_venues) { all_venues.first(2) }
+
+          it "returns filtered venues" do
+            expect(response.body).to eq filtered_venues.to_json
+          end
+        end
+
+        context "when filtered results are not found" do
+          let(:filtered_venues) { [] }
+
+          it "returns all venues" do
+            expect(response.body).to eq all_venues.to_json
+          end
         end
       end
 
-      context "when filtered results are not found" do
-        let(:filtered_venues) { [] }
+      context "when production ids are not provided" do
+        let(:params) { {} }
 
-        it "returns all venues" do
+        it "immediately retrieves all venues" do
+          expect(Venue).not_to have_received(:for_production_ids)
           expect(response.body).to eq all_venues.to_json
         end
       end

--- a/vendor/engines/production_credits/spec/controllers/production_credits/venues_controller_spec.rb
+++ b/vendor/engines/production_credits/spec/controllers/production_credits/venues_controller_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+module ProductionCredits
+  RSpec.describe VenuesController, type: :controller do
+    routes { ProductionCredits::Engine.routes }
+
+    describe "#index" do
+      let(:params) { { production_ids: ids } }
+      let(:ids) { %w[1 2 3] }
+      let(:all_venues) { 5.times.map { |n| double(to_json: { name: "VENUE #{n}" }) } }
+
+      before do
+        allow(Venue).to receive(:for_production_ids).with(ids) { filtered_venues }
+        allow(Venue).to receive(:all) { all_venues }
+
+        get :index, params
+      end
+
+      context "when filtered results are found" do
+        let(:filtered_venues) { all_venues.first(2) }
+
+        it "returns filtered venues" do
+          expect(response.body).to eq filtered_venues.to_json
+        end
+      end
+
+      context "when filtered results are not found" do
+        let(:filtered_venues) { [] }
+
+        it "returns all venues" do
+          expect(response.body).to eq all_venues.to_json
+        end
+      end
+    end
+  end
+end

--- a/vendor/engines/production_credits/spec/factories/production_credits_productions.rb
+++ b/vendor/engines/production_credits/spec/factories/production_credits_productions.rb
@@ -1,4 +1,5 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
+require "faker"
 
 FactoryGirl.define do
   factory :production_credits_production, :class => 'ProductionCredits::Production' do

--- a/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
+++ b/vendor/engines/production_credits/spec/models/production_credits/venue_spec.rb
@@ -5,6 +5,18 @@ module ProductionCredits
     let!(:canonical_venue) { Venue.create!(name: "Canonical") }
     let!(:alias_venue) { Venue.create!(name: "Alias", canonical_venue: canonical_venue) }
 
+    describe "scoping venues to productions" do
+      let!(:production) { FactoryGirl.create(:production_credits_production) }
+
+      before do
+        canonical_venue.productions << production
+      end
+
+      it "finds venues associated with the production" do
+        expect(Venue.for_production_ids(production.id)).to eq [canonical_venue]
+      end
+    end
+
     describe "alias validation" do
       context "when adding an alias to a canonical venue" do
         let(:venue) { canonical_venue }
@@ -57,7 +69,7 @@ module ProductionCredits
         end
 
         it "is not valid" do
-            expect(venue).not_to be_valid
+          expect(venue).not_to be_valid
         end
       end
     end


### PR DESCRIPTION
When selecting one or more productions for an item, restrict the venue selection list to only those venues associated with the selected productions.

For now, we do this by disabling any other venues.  With chosen.js, those disabled venues will be in the list, but unselectable.  We can change this behavior with an option if we decide to do that later.
