### PR TITLE
Allow toggling between full date and year only

### DIFF
--- a/app/assets/javascripts/sufia_customization/date_created.js.coffee
+++ b/app/assets/javascripts/sufia_customization/date_created.js.coffee
@@ -1,0 +1,54 @@
+@SufiaCustomizations ?= {}
+
+class @SufiaCustomizations.DateCreated
+  constructor: ->
+    @_yearOnly = $("#generic_file_has_year_only")
+    @_dateCreated = new FormGroup $("div.generic_file_date_created")
+    @_yearCreated = new FormGroup $("div.generic_file_year_created")
+
+    @_hookupStateUpdates()
+
+  _hookupStateUpdates: ->
+    @_yearOnly.on "change", @_updateState
+    @_updateState()
+
+  _updateState: =>
+    if @_yearOnly.is ":checked"
+      @_switchToYearOnly()
+    else
+      @_switchToDate()
+
+  _switchToYearOnly: ->
+    @_dateCreated.disable()
+    @_yearCreated.enable()
+    @_defaultYear @_dateCreated.value()
+
+  _defaultYear: (dateString) ->
+    return if @_yearCreated.value()
+
+    date = if dateString then new Date(dateString) else new Date()
+    @_yearCreated.setValue date.getFullYear()
+
+  _switchToDate: ->
+    @_yearCreated.disable()
+    @_dateCreated.enable()
+
+class FormGroup
+  constructor: (@_group) ->
+    @_input = @_group.find "input"
+
+  enable: ->
+    @_input.attr "required", "required"
+    @_input.attr "aria-required", "true"
+    @_group.removeClass "is-hidden"
+
+  disable: ->
+    @_group.addClass "is-hidden"
+    @_input.removeAttr "required"
+    @_input.removeAttr "aria-required"
+
+  value: ->
+    @_input.val()
+
+  setValue: (value) ->
+    @_input.val(value)

--- a/app/assets/javascripts/sufia_customization/production_credits.js.coffee
+++ b/app/assets/javascripts/sufia_customization/production_credits.js.coffee
@@ -1,0 +1,44 @@
+@SufiaCustomizations ?= {}
+
+class @SufiaCustomizations.ProductionCredits
+  constructor: ->
+    @_productionIds = $("#generic_file_production_ids")
+    @_venueIds = $("#generic_file_venue_ids")
+    @_initializeProductionsSelector()
+    @_initializeVenuesSelector()
+    @_initializeEventTypeSelector()
+
+    @_hookupVenueSelectionsUpdate()
+
+  _initializeProductionsSelector: ->
+    @_productionIds.chosen
+      placeholder_text_multiple: "Select production(s)"
+      search_contains: true
+      single_backstroke_delete: false
+
+  _initializeVenuesSelector: ->
+    @_venueIds.chosen
+      placeholder_text_multiple: "Select venue(s)"
+      search_contains: true
+      single_backstroke_delete: false
+
+  _initializeEventTypeSelector: ->
+    $("#generic_file_event_type_id").chosen
+      placeholder_text_single: "Select an event type"
+      allow_single_deselect: true
+      search_contains: true
+      single_backstroke_delete: false
+
+  _hookupVenueSelectionsUpdate: ->
+    @_productionIds.on "change", @_productionSelectionsChanged
+    @_productionSelectionsChanged()
+
+  _productionSelectionsChanged: =>
+    ids = @_productionIds.val() ? []
+    query = ("production_ids[]=#{id}" for id in ids).join("&")
+    $.get "/production_credits/venues.json?#{query}", @_updateVenueChoiceEnablement
+
+  _updateVenueChoiceEnablement: (venues) =>
+    @_venueIds.find("option").attr "disabled", "disabled"
+    @_venueIds.find("option[value='#{venue.id}']").removeAttr("disabled") for venue in venues
+    @_venueIds.trigger("chosen:updated")

--- a/app/assets/javascripts/sufia_customization/widgets.js.coffee
+++ b/app/assets/javascripts/sufia_customization/widgets.js.coffee
@@ -1,8 +1,8 @@
 @SufiaCustomizations ?= {}
 
 @SufiaCustomizations.initialize = ->
-    new SufiaCustomizations.DateCreated
-    new SufiaCustomizations.ProductionCredits
+  new SufiaCustomizations.DateCreated
+  new SufiaCustomizations.ProductionCredits
 
 $(document).on 'ready page:load', ->
   SufiaCustomizations.initialize()

--- a/app/assets/javascripts/sufia_customization/widgets.js.coffee
+++ b/app/assets/javascripts/sufia_customization/widgets.js.coffee
@@ -1,47 +1,8 @@
 @SufiaCustomizations ?= {}
 
-class @SufiaCustomizations.Initialize
-  constructor: ->
-    @_productionIds = $("#generic_file_production_ids")
-    @_venueIds = $("#generic_file_venue_ids")
-    @_initializeProductionsSelector()
-    @_initializeVenuesSelector()
-    @_initializeEventTypeSelector()
-
-    @_hookupVenueSelectionsUpdate()
-
-  _initializeProductionsSelector: ->
-    @_productionIds.chosen
-      placeholder_text_multiple: "Select production(s)"
-      search_contains: true
-      single_backstroke_delete: false
-
-  _initializeVenuesSelector: ->
-    @_venueIds.chosen
-      placeholder_text_multiple: "Select venue(s)"
-      search_contains: true
-      single_backstroke_delete: false
-
-  _initializeEventTypeSelector: ->
-    $("#generic_file_event_type_id").chosen
-      placeholder_text_single: "Select an event type"
-      allow_single_deselect: true
-      search_contains: true
-      single_backstroke_delete: false
-
-  _hookupVenueSelectionsUpdate: ->
-    @_productionIds.on "change", @_productionSelectionsChanged
-    @_productionSelectionsChanged()
-
-  _productionSelectionsChanged: =>
-    ids = @_productionIds.val() ? []
-    query = ("production_ids[]=#{id}" for id in ids).join("&")
-    $.get "/production_credits/venues.json?#{query}", @_updateVenueChoiceEnablement
-
-  _updateVenueChoiceEnablement: (venues) =>
-    @_venueIds.find("option").attr "disabled", "disabled"
-    @_venueIds.find("option[value='#{venue.id}']").removeAttr("disabled") for venue in venues
-    @_venueIds.trigger("chosen:updated")
+@SufiaCustomizations.initialize = ->
+    new SufiaCustomizations.DateCreated
+    new SufiaCustomizations.ProductionCredits
 
 $(document).on 'ready page:load', ->
-  new SufiaCustomizations.Initialize()
+  SufiaCustomizations.initialize()

--- a/app/assets/stylesheets/overrides/sufia.css.scss
+++ b/app/assets/stylesheets/overrides/sufia.css.scss
@@ -1,3 +1,7 @@
+.is-hidden {
+  display: none;
+}
+
 #home_header {
   background: image-url("home_bg.jpg") center 100% no-repeat;
   background-size: cover;

--- a/app/controllers/generic_files_controller.rb
+++ b/app/controllers/generic_files_controller.rb
@@ -6,6 +6,13 @@ class GenericFilesController < ApplicationController
   self.edit_form_class = FileEditForm
 
   def update
+    file_params = params[:generic_file] || {}
+    if ActiveRecord::Type::Boolean.new.type_cast_from_user(file_params.delete(:has_year_only))
+      file_params[:date_created] = []
+    else
+      file_params[:year_created] = nil
+    end
+
     if params[:visibility] == "discoverable"
       @generic_file.set_discover_groups(%w[public], [])
       params[:visibility] = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED

--- a/app/forms/file_edit_form.rb
+++ b/app/forms/file_edit_form.rb
@@ -2,5 +2,5 @@ class FileEditForm < GenericFilePresenter
   include HydraEditor::Form
   include HydraEditor::Form::Permissions
 
-  self.required_fields = %i[title rights date_created resource_type]
+  self.required_fields = %i[title rights date_created year_created resource_type]
 end

--- a/app/helpers/generic_file_production_helper.rb
+++ b/app/helpers/generic_file_production_helper.rb
@@ -21,9 +21,11 @@ module GenericFileProductionHelper
 
   def formatted_creation_date(file)
     date = file.date_created.first
-    return "" unless date
-
-    date.to_date.to_s(:mdy)
+    if date
+      date.to_date.to_s(:mdy)
+    else
+      file.year_created
+    end
   end
 
   def unreadable?(file)

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -1,6 +1,8 @@
 class GenericFile < ActiveFedora::Base
   include Sufia::GenericFile
 
+  before_save :set_calculated_fields
+
   def self.property(name, multiple:, &block)
     predicate = ::RDF::URI("http://docs.osfashland.org/terms/#{name}")
     super(name, predicate: predicate, multiple: multiple, &block)
@@ -49,8 +51,6 @@ class GenericFile < ActiveFedora::Base
     index.as :stored_sortable, :facetable
   end
 
-  before_save :set_calculated_fields
-
   def discoverable?
     discover_groups.include?("public")
   end
@@ -61,6 +61,7 @@ class GenericFile < ActiveFedora::Base
     UpdatesProductionCredits.update(self)
     year = year_from_date_created
     self.year_created = year if year
+    self.year_created = year_created.to_i if year_created.present?
   end
 
   def year_from_date_created

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -59,10 +59,11 @@ class GenericFile < ActiveFedora::Base
 
   def set_calculated_fields
     UpdatesProductionCredits.update(self)
-    self.year_created = creation_year
+    year = year_from_date_created
+    self.year_created = year if year
   end
 
-  def creation_year
+  def year_from_date_created
     first_date = date_created.try(:first)
     first_date && Date.parse(first_date).year
   rescue ArgumentError

--- a/app/presenters/generic_file_presenter.rb
+++ b/app/presenters/generic_file_presenter.rb
@@ -9,6 +9,7 @@ class GenericFilePresenter < Sufia::GenericFilePresenter
     :rights,
     :publisher,
     :date_created,
+    :year_created,
     :language,
     :identifier,
     :based_near,
@@ -23,4 +24,8 @@ class GenericFilePresenter < Sufia::GenericFilePresenter
   delegate :production_names, :venue_names, :venue_full_names, :event_type_name, to: :model
 
   delegate :public?, :discoverable?, :restricted?, :private?, to: :model
+
+  def has_year_only
+    model.date_created.blank? && model.year_created.present?
+  end
 end

--- a/app/views/records/edit_fields/_date_created.html.erb
+++ b/app/views/records/edit_fields/_date_created.html.erb
@@ -1,4 +1,8 @@
-<div class="form-group optional generic_file_identifier">
+<div class="form-group optional generic_file_has_year_only">
+  <%= f.input :has_year_only, as: :boolean, label: "Year Only?" %>
+</div>
+
+<div class="form-group optional generic_file_date_created">
   <%= f.label :date_created %>
   <%= f.date_field :date_created,
                    class: 'form-control',

--- a/app/views/records/edit_fields/_year_created.html.erb
+++ b/app/views/records/edit_fields/_year_created.html.erb
@@ -1,0 +1,8 @@
+<%= f.input :year_created,
+            as: :integer,
+            label: "Year Created",
+            input_html: {
+              class: 'form-control',
+              min: 1935
+            }
+%>

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -41,5 +41,18 @@ describe GenericFile do
         expect { file.save! }.not_to change { file.year_created }
       end
     end
+
+    context "when creation year is a string" do
+      # For some reason, Sufia is giving us a string instead of a year from
+      # its update action.
+      before do
+        file.year_created = "1972"
+        file.save!
+      end
+
+      it "converts the string to an integer" do
+        expect(file.year_created).to eq 1972
+      end
+    end
   end
 end

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -24,11 +24,10 @@ describe GenericFile do
       before do
         file.date_created = nil
         file.year_created = 1492
-        file.save!
       end
 
-      it "clears the creation year" do
-        expect(file.year_created).to be_blank
+      it "leaves the creation year alone" do
+        expect { file.save! }.not_to change { file.year_created }
       end
     end
 
@@ -36,11 +35,10 @@ describe GenericFile do
       before do
         file.date_created = []
         file.year_created = 1492
-        file.save!
       end
 
-      it "clears the creation year" do
-        expect(file.year_created).to be_blank
+      it "leaves the creation year alone" do
+        expect { file.save! }.not_to change { file.year_created }
       end
     end
   end


### PR DESCRIPTION
Add a checkbox that toggles between a date selector and a year selector.

When toggling to the year selector, default the year based on the selected date, but only if there isn’t already a year present.

The interaction design might need some tweaking.
