### PR TITLE
Allow batch edits to work with has_year_only checkbox

### DIFF
--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -55,6 +55,10 @@ class GenericFile < ActiveFedora::Base
     discover_groups.include?("public")
   end
 
+  def has_year_only?
+    date_created.blank? && year_created.present?
+  end
+
   private
 
   def set_calculated_fields

--- a/app/presenters/generic_file_presenter.rb
+++ b/app/presenters/generic_file_presenter.rb
@@ -23,9 +23,5 @@ class GenericFilePresenter < Sufia::GenericFilePresenter
   # Names are not displayed directly so don't include them in `terms'.
   delegate :production_names, :venue_names, :venue_full_names, :event_type_name, to: :model
 
-  delegate :public?, :discoverable?, :restricted?, :private?, to: :model
-
-  def has_year_only
-    model.date_created.blank? && model.year_created.present?
-  end
+  delegate :public?, :discoverable?, :restricted?, :private?, :has_year_only?, to: :model
 end

--- a/app/views/records/edit_fields/_date_created.html.erb
+++ b/app/views/records/edit_fields/_date_created.html.erb
@@ -1,5 +1,5 @@
 <div class="form-group optional generic_file_has_year_only">
-  <%= f.input :has_year_only, as: :boolean, label: "Year Only?" %>
+  <%= f.input :has_year_only?, as: :boolean, label: "Year Only?" %>
 </div>
 
 <div class="form-group optional generic_file_date_created">

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -55,4 +55,24 @@ describe GenericFile do
       end
     end
   end
+
+  describe "year only" do
+    [
+        # context                         date          year  result
+      [ "neither creation date nor year", nil,          nil,  false ],
+      [ "only a creation year",           nil,          1992, true  ],
+      [ "both creation date and year",    "10/15/2015", 2015, false ]
+    ].each do |description, date, year, expected|
+      context "when file has #{description}" do
+        before do
+          file.date_created = Array(date)
+          file.year_created = year
+        end
+
+        it "#{expected ? 'has' : 'does not have'} a year only" do
+          expect(file.has_year_only?).to eq expected
+        end
+      end
+    end
+  end
 end

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -58,7 +58,7 @@ describe GenericFile do
 
   describe "year only" do
     [
-        # context                         date          year  result
+      # context                           date          year  result
       [ "neither creation date nor year", nil,          nil,  false ],
       [ "only a creation year",           nil,          1992, true  ],
       [ "both creation date and year",    "10/15/2015", 2015, false ]


### PR DESCRIPTION
When doing batch edits, the model for the form is a `GenericFile` that
is not wrapped in a presenter as with normal edits and uploads.  As a
result, the `has_year_only` method from the presenter was not available
in that context, resulting in an error.

I moved the method over to the model and added a table-driven test.

I also realized that I could rename the method to `has_year_only?`
instead of `has_year_only` and use that new name in the view as well.
This addresses an earlier annoyance.

The batch edit view around these two fields and the checkbox is not
optimal and may need to be addressed.
