### PR TITLE
Ensure production credits selectors display correctly

### DIFF
--- a/app/assets/javascripts/sufia_customization/production_credits.js.coffee
+++ b/app/assets/javascripts/sufia_customization/production_credits.js.coffee
@@ -15,12 +15,14 @@ class @SufiaCustomizations.ProductionCredits
       placeholder_text_multiple: "Select production(s)"
       search_contains: true
       single_backstroke_delete: false
+      width: "100%"
 
   _initializeVenuesSelector: ->
     @_venueIds.chosen
       placeholder_text_multiple: "Select venue(s)"
       search_contains: true
       single_backstroke_delete: false
+      width: "100%"
 
   _initializeEventTypeSelector: ->
     $("#generic_file_event_type_id").chosen
@@ -28,6 +30,7 @@ class @SufiaCustomizations.ProductionCredits
       allow_single_deselect: true
       search_contains: true
       single_backstroke_delete: false
+      width: "100%"
 
   _hookupVenueSelectionsUpdate: ->
     @_productionIds.on "change", @_productionSelectionsChanged


### PR DESCRIPTION
In the bulk upload form, the production credits selectors are initially
hidden.  Because of a [known bug in
chosen.js](https://github.com/harvesthq/chosen/issues/92), that causes
the Chosen widget to have a width of 0px.

The [Chosen
documentation](https://harvesthq.github.io/chosen/options.html)
indicates that you must specify a width explicitly in this case.

Based on the styling of the underlying select element, I chose to use
`width: “100%”`, and that seems to work quite well.
