### PR TITLE
Use proper param separator when no search terms

### DIFF
--- a/app/assets/javascripts/client/fetches_results.js.coffee
+++ b/app/assets/javascripts/client/fetches_results.js.coffee
@@ -2,16 +2,22 @@
 
 class @App.FetchesResults
   constructor: ->
-    @_url = window.location.search
+    @_search = window.location.search
 
   fetch: (resultType, page, success) ->
-    $.get "/#{resultType}#{@_url}&page=#{page}", success
+    page_param = "page=#{page}"
+    params = if @_search == ""
+      "?#{page_param}"
+    else
+      "#{@_search}&#{page_param}"
+
+    $.get "/#{resultType}#{params}", success
 
   addResultType: (resultType) ->
-    @_url = @_url.concat(@_resultTypeFragment(resultType))
+    @_search = @_search.concat(@_resultTypeFragment(resultType))
 
   removeResultType: (resultType) ->
-    @_url = @_url.replace(@_resultTypeFragment(resultType), "")
+    @_search = @_search.replace(@_resultTypeFragment(resultType), "")
 
   _resultTypeFragment: (resultType) ->
     "&types%5B%5D=#{resultType}"


### PR DESCRIPTION
On initial query, our item queries were using URLs of the form
`/audios&page=1` instead of the correct `/audios?page=1`.  We now
correctly format the URL in both cases (with and without additional
parameters).
